### PR TITLE
Fix menu spelling in changelog

### DIFF
--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -161,7 +161,7 @@ function wrapper(plugin_info) {
         {
             version: '2.2.7',
             changes: [
-                'FIX: Menue Buttons in Mobile version are now actually buttons.',
+                'FIX: Menu Buttons in Mobile version are now actually buttons.',
             ],
         },
         {


### PR DESCRIPTION
## Summary
- correct spelling of "Menu Buttons" in changelog for version 2.2.7

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6849aef2440083328efe1a818f5711cc