### PR TITLE
FIX: Compatibility with Inventory Overview plugin

### DIFF
--- a/iitc_plugin_fanfields2.meta.js
+++ b/iitc_plugin_fanfields2.meta.js
@@ -3,7 +3,7 @@
 // @name            Fan Fields 2 
 // @id              fanfields@heistergand
 // @category        Layer
-// @version         2.6.3.20250611
+// @version         2.6.4.20250912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -1,9 +1,8 @@
 // ==UserScript==
 // @author          Heistergand
-// @name            Fan Fields 2 
 // @id              fanfields@heistergand
 // @category        Layer
-// @version         2.6.3.20250611
+// @version         2.6.4.20250912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -49,6 +48,12 @@ function wrapper(plugin_info) {
     /* exported setup, changelog --eslint */
     let arcname = window.PLAYER.team === 'ENLIGHTENED' ? 'Arc' : '***';
     var changelog = [
+        {
+            version: '2.6.4',
+            changes: [
+                'FIX: Fixed compatibility with Inventory Overview plugin.',
+            ],
+        },
         {
             version: '2.6.3',
             changes: [
@@ -640,8 +645,10 @@ function wrapper(plugin_info) {
             let availableKeysText = '';
             let availableKeys = 0;
             if (window.plugin.keys || window.plugin.LiveInventory) {
-                if (window.plugin.LiveInventory) {
+                if (window.plugin.LiveInventory.keyGuidCount) {
                     availableKeys = window.plugin.LiveInventory.keyGuidCount[portal.guid] || 0;
+                } else if (window.plugin.LiveInventory.keyCount) {
+                    availableKeys = window.plugin.LiveInventory.keyCount.find(obj => obj.portalCoupler.portalGuid === portal.guid)?.count || 0;
                 } else {
                     availableKeys = window.plugin.keys.keys[portal.guid] || 0;
                 }


### PR DESCRIPTION
Fixes the function to show as a list when using Inventory overview plugin

Inventory overview overwrites the LiveInventory plugin, implementing a different interface to the data, crashing the count for keys

Fixes #85 