### PR TITLE
Add optional Portal Route export

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Use this plugin to easily plan your fanfields. It tells you how many keys you ne
 - IITC plugin: Arc
 - IITC plugin: [Keys](https://iitc.app/download_desktop#keys-by-xelio) by xelio
 - IITC Plugin: [Live Inventory](https://github.com/IITC-CE/Community-plugins?tab=readme-ov-file#live-inventory-by-eisfrei---fork-by-danielondiordna) by EisFrei - fork by DanielOnDiordna
+- IITC Plugin: [Portal Route](https://iitc.app/community_plugins#portal-route-by-MikeDiehn) by Mike Diehn
 
 ## Features
 - Select portals in your area by drawing a polygon around them with DrawTools. 
@@ -31,7 +32,8 @@ Use this plugin to easily plan your fanfields. It tells you how many keys you ne
     - link order
     - target portal name
     - link distance
-- Open the path along the Portals in google maps.
+- Plot a route along the portals in IITC with Portal Route
+- Open the path along the portals in Google Maps.
 - Tweak your plan:
   - Move the anchor portal along the hull of the area.
   - Set a marker to a portal inside the hull to make it a possible anchor. _(Yes, you can actually make a 360° fan field. Still has issues though.)_

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -738,33 +738,17 @@ function wrapper(plugin_info) {
   }
 
 
-  thisplugin.isCompatiblePortalRoutePlugin = function (routePlugin) {
+  thisplugin.isCompatiblePortalRoutePlugin = function () {
+    var routePlugin = window.plugin && window.plugin.portalRoute;
     if (!routePlugin) return false;
     if (typeof routePlugin.replaceStops === 'function') return true;
     return (typeof routePlugin.clearStops === 'function' && typeof routePlugin.addStop === 'function');
   };
 
   thisplugin.getPortalRoutePlugin = function () {
-    if (!window.plugin) return null;
-
-    var candidates = [
-      window.plugin.portalRoute,
-      window.plugin.portalRoutes,
-      window.plugin.drivingRoute
-    ];
-
-    for (var i = 0; i < candidates.length; i++) {
-      if (thisplugin.isCompatiblePortalRoutePlugin(candidates[i])) {
-        return candidates[i];
-      }
-    }
-
-    return null;
-  };
-
-  thisplugin.getAnyPortalRoutePlugin = function () {
-    if (!window.plugin) return null;
-    return window.plugin.portalRoute || window.plugin.portalRoutes || window.plugin.drivingRoute || null;
+    return thisplugin.isCompatiblePortalRoutePlugin()
+      ? window.plugin.portalRoute
+      : null;
   };
 
   thisplugin.getPortalRouteStops = function () {
@@ -1016,7 +1000,10 @@ function wrapper(plugin_info) {
       '</div>';
 
     text += '<div style="margin-top:10px;">';
-    text += '<a id="plugin_fanfields2_portal_route_link" href="#">Route with Portal Route</a><br>';
+    if (thisplugin.isCompatiblePortalRoutePlugin()) {
+      text += '<a id="plugin_fanfields2_portal_route_link" href="#">Route with Portal Route</a><br>';
+    }
+    
     text += '<a target="_blank" href="' + gmnav + '">Navigate with Google Maps</a>';
     text += '</div>';
 
@@ -1072,16 +1059,16 @@ function wrapper(plugin_info) {
         thisplugin.exportTaskListToPDF();
       });
 
-    $('#plugin_fanfields2_portal_route_link')
-      .off('click')
-      .on('click', function (ev) {
-        ev.preventDefault();
-        thisplugin.routeWithPortalRoute();
-      });
-
+    if (thisplugin.isCompatiblePortalRoutePlugin()) {
+      $('#plugin_fanfields2_portal_route_link')
+        .off('click')
+        .on('click', function (ev) {
+          ev.preventDefault();
+          thisplugin.routeWithPortalRoute();
+        });
+    }
 
   };
-
 
   thisplugin.exportTaskListToPDF = function () {
     const id = 'plugin_fanfields2_alert_textExport';

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -737,6 +737,104 @@ function wrapper(plugin_info) {
     else window.urlPortal = guid;
   }
 
+
+  thisplugin.isCompatiblePortalRoutePlugin = function (routePlugin) {
+    if (!routePlugin) return false;
+    if (typeof routePlugin.replaceStops === 'function') return true;
+    return (typeof routePlugin.clearStops === 'function' && typeof routePlugin.addStop === 'function');
+  };
+
+  thisplugin.getPortalRoutePlugin = function () {
+    if (!window.plugin) return null;
+
+    var candidates = [
+      window.plugin.portalRoute,
+      window.plugin.portalRoutes,
+      window.plugin.drivingRoute
+    ];
+
+    for (var i = 0; i < candidates.length; i++) {
+      if (thisplugin.isCompatiblePortalRoutePlugin(candidates[i])) {
+        return candidates[i];
+      }
+    }
+
+    return null;
+  };
+
+  thisplugin.getAnyPortalRoutePlugin = function () {
+    if (!window.plugin) return null;
+    return window.plugin.portalRoute || window.plugin.portalRoutes || window.plugin.drivingRoute || null;
+  };
+
+  thisplugin.getPortalRouteStops = function () {
+    return thisplugin.sortedFanpoints.map(function (portal) {
+      var latlng = map.unproject(portal.point, thisplugin.PROJECT_ZOOM);
+      var p = portal.portal || window.portals[portal.guid];
+      var title = 'unknown title';
+
+      if (p && p.options && p.options.data && p.options.data.title) {
+        title = p.options.data.title;
+      }
+
+      return {
+        guid: portal.guid || null,
+        title: title,
+        lat: latlng.lat,
+        lng: latlng.lng
+      };
+    });
+  };
+
+  thisplugin.routeWithPortalRoute = function () {
+    var routePlugin = thisplugin.getPortalRoutePlugin();
+
+    if (!routePlugin) {
+      var anyRoutePlugin = thisplugin.getAnyPortalRoutePlugin();
+      dialog({
+        html: anyRoutePlugin
+          ? '<p>Portal Route is loaded, but does not expose a compatible route import function.</p>'
+          : '<p>Portal Route is not loaded.</p>',
+        id: anyRoutePlugin ? 'plugin_fanfields2_alert_portal_route_incompatible' : 'plugin_fanfields2_alert_portal_route_missing',
+        title: 'Fan Fields 2 - Portal Route',
+        width: anyRoutePlugin ? 400 : 350,
+        closeOnEscape: true
+      });
+      return;
+    }
+
+    var stops = thisplugin.getPortalRouteStops();
+    if (!stops.length) return;
+
+    if (typeof routePlugin.replaceStops === 'function') {
+      routePlugin.replaceStops(stops, { openPanel: true, clearRoute: true });
+      return;
+    }
+
+    if (typeof routePlugin.clearStops === 'function' && typeof routePlugin.addStop === 'function') {
+      routePlugin.clearStops();
+      stops.forEach(function (stop) {
+        routePlugin.addStop(stop);
+      });
+
+      if (routePlugin.state) routePlugin.state.panelOpen = true;
+      if (typeof routePlugin.savePanelOpen === 'function') routePlugin.savePanelOpen();
+      if (typeof routePlugin.renderPanel === 'function') routePlugin.renderPanel();
+      if (typeof routePlugin.showMessage === 'function') {
+        routePlugin.showMessage('Imported ' + stops.length + ' Fan Fields stops.');
+      }
+      return;
+    }
+
+    dialog({
+      html: '<p>Portal Route is loaded, but does not expose a compatible route import function.</p>',
+      id: 'plugin_fanfields2_alert_portal_route_incompatible',
+      title: 'Fan Fields 2 - Portal Route',
+      width: 400,
+      closeOnEscape: true
+    });
+  };
+
   // Show as list
   thisplugin.exportText = function () {
     var text = '<table><thead><tr>';
@@ -917,7 +1015,10 @@ function wrapper(plugin_info) {
       '  <button id="plugin_fanfields2_export_pdf_btn">Print</button>' +
       '</div>';
 
+    text += '<div style="margin-top:10px;">';
+    text += '<a id="plugin_fanfields2_portal_route_link" href="#">Route with Portal Route</a><br>';
     text += '<a target="_blank" href="' + gmnav + '">Navigate with Google Maps</a>';
+    text += '</div>';
 
     thisplugin.exportDialogWidth = 500;
 
@@ -969,6 +1070,13 @@ function wrapper(plugin_info) {
       .off('click')
       .on('click', function () {
         thisplugin.exportTaskListToPDF();
+      });
+
+    $('#plugin_fanfields2_portal_route_link')
+      .off('click')
+      .on('click', function (ev) {
+        ev.preventDefault();
+        thisplugin.routeWithPortalRoute();
       });
 
 


### PR DESCRIPTION
This adds an optional “Route with Portal Route” action to the Fan Fields 2 task list.

The existing Google Maps navigation link is unchanged. If the [Portal Route IITC plugin](https://github.com/mdiehn/iitc-plugin-portal-route) is loaded and exposes a compatible route import function (which is now does), Fan Fields 2 can now send the current ordered portal sequence directly to Portal Route.

What it does:

- Builds route stops from the existing `sortedFanpoints` task-list order
- Sends portal GUID, title, latitude, and longitude to Portal Route
- Uses `replaceStops()` when available
- Shows a clear message if Portal Route is not loaded or does not expose a compatible import API
- Does not add Portal Route as a hard dependency
- Leaves the existing Google Maps export behavior intact

This is intended as a lightweight integration point for players who use both Fan Fields 2 and Portal Route for route planning.