### PR TITLE
Fix Respect Intel handling of existing own links

### DIFF
--- a/iitc_plugin_fanfields2.meta.js
+++ b/iitc_plugin_fanfields2.meta.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.1.20260501
+// @version         2.8.2.20260506
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.1.20260501
+// @version         2.8.2.20260506
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-02-18-004642';
+  plugin_info.dateTimeVersion = '2026-05-06-233150';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin, formatDistance  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.2',
+      changes: [
+        'FIX: Respect Intel integrates already existing own-faction links into planned fields.',
+      ],
+    },{
       version: '2.8.1',
       changes: [
         'NEW: Add support for 3rd party plugin "Portal Route".',
@@ -621,7 +626,8 @@ function wrapper(plugin_info) {
         '<p><b>Avoid blockers</b><br>' +
         'If you need to plan around links you cannot or do not want to destroy, use <i>Respect&nbsp;Intel</i>. ' +
         'Choose which factions\' links are treated as blockers (NONE / ALL / ENL / RES / ENL &amp; MAC / RES &amp; MAC / MAC). ' +
-        'The plan avoids crossing those currently visible intel links.</p>' +
+        'The plan avoids crossing those currently visible intel links. When the selected mode includes your own faction, existing visible links from your own faction, ' +
+        'with both portals inside the selected area, are integrated as already-built links for field planning.</p>' +
 
         '<p><b>Order & route planning</b><br>' +
         'Switch between <i>Clockwise</i> and <i>Counterclockwise</i> order to find an easier route or squeeze out extra fields. ' +
@@ -1497,6 +1503,28 @@ function wrapper(plugin_info) {
     }
   };
 
+  thisplugin.getOwnFactionTeam = function () {
+    if (!window.PLAYER) return undefined;
+
+    if (window.PLAYER.team === 'ENLIGHTENED' || window.PLAYER.team === window.TEAM_ENL) {
+      return window.TEAM_ENL;
+    }
+
+    if (window.PLAYER.team === 'RESISTANCE' || window.PLAYER.team === window.TEAM_RES) {
+      return window.TEAM_RES;
+    }
+
+    return undefined;
+  };
+
+  thisplugin.isOwnFactionRespected = function () {
+    var ownTeam = thisplugin.getOwnFactionTeam();
+    if (ownTeam === undefined) return false;
+
+    return thisplugin.getRespectIntelTeams()
+      .indexOf(ownTeam) !== -1;
+  };
+
   thisplugin.getRespectIntelLabel = function () {
     switch (thisplugin.respectIntelLinksMode) {
       case thisplugin.respectIntelLinksModeENUM.ALL:
@@ -2269,6 +2297,7 @@ function wrapper(plugin_info) {
   thisplugin.validTriangles = null;
   thisplugin.validLinkCount = 0;
   thisplugin.validTriangleCount = 0;
+  thisplugin.existingIntelPlanLinks = [];
 
   thisplugin.pointKey = function (p) {
     return p.x + ',' + p.y;
@@ -2339,6 +2368,15 @@ function wrapper(plugin_info) {
 
     // Track successful links (undirected) so we can decide which triangles can actually be formed.
     var builtLinks = {};
+    var existingIntelPlanLinks = thisplugin.existingIntelPlanLinks || [];
+    for (var ei = 0; ei < existingIntelPlanLinks.length; ei++) {
+      var existingLink = existingIntelPlanLinks[ei];
+      var existingGuidA = existingLink.guidA || pointToGuid[thisplugin.pointKey(existingLink.a)];
+      var existingGuidB = existingLink.guidB || pointToGuid[thisplugin.pointKey(existingLink.b)];
+      if (existingGuidA && existingGuidB) {
+        builtLinks[thisplugin.getUndirectedLinkKey(existingGuidA, existingGuidB)] = true;
+      }
+    }
 
     // Track whether a portal is under a field at the moment we arrive there.
     var portalUnderFieldAtVisit = {};
@@ -2675,6 +2713,7 @@ function wrapper(plugin_info) {
     thisplugin.startingMarker = undefined;
     thisplugin.startingMarkerGUID = undefined;
     thisplugin.centerKeys = 0;
+    thisplugin.existingIntelPlanLinks = [];
 
 
 
@@ -2866,6 +2905,37 @@ function wrapper(plugin_info) {
 
     // Store signature for the next run
     thisplugin.lastPlanSignature = currentSignature;
+
+    thisplugin.existingIntelPlanLinks = [];
+    if (thisplugin.isOwnFactionRespected()) {
+      var ownTeam = thisplugin.getOwnFactionTeam();
+      var fanpointGuidByPoint = {};
+      for (guid in this.fanpoints) {
+        fanpointGuidByPoint[thisplugin.pointKey(this.fanpoints[guid])] = guid;
+      }
+
+      if (ownTeam !== undefined) {
+        thisplugin.existingIntelPlanLinks = Object.values(thisplugin.intelLinks)
+          .filter(function (link) {
+            var guidA = fanpointGuidByPoint[thisplugin.pointKey(link.a)];
+            var guidB = fanpointGuidByPoint[thisplugin.pointKey(link.b)];
+            return link.team === ownTeam && guidA && guidB;
+          })
+          .map(function (link) {
+            var guidA = fanpointGuidByPoint[thisplugin.pointKey(link.a)];
+            var guidB = fanpointGuidByPoint[thisplugin.pointKey(link.b)];
+            return {
+              a: link.a,
+              b: link.b,
+              team: link.team,
+              guidA: guidA,
+              guidB: guidB,
+              isExistingIntelLink: true,
+              counts: false
+            };
+          });
+      }
+    }
 
 
 
@@ -3203,9 +3273,15 @@ function wrapper(plugin_info) {
               break;
             }
           }
-          if (intersection === 0 && this.linkExists(maplinks, possibleline)) {
+          var existsAsBlockingIntelLink = this.linkExists(maplinks, possibleline);
+          var existsAsOwnIntelLink = this.linkExists(thisplugin.existingIntelPlanLinks, possibleline);
+          if (intersection === 0 && (existsAsBlockingIntelLink || existsAsOwnIntelLink)) {
             possibleline.counts = false;
-            if (possibleline.isFanLink && outbound === 1) centerOutgoings--;
+            if (possibleline.isFanLink && outbound === 1) {
+              centerOutgoings--;
+            } else if (possibleline.isFanLink) {
+              thisplugin.centerKeys--;
+            }
           }
         }
         if (intersection === 0) {
@@ -3238,8 +3314,7 @@ function wrapper(plugin_info) {
           var thirds = [];
           if (thisplugin.isRespectingIntel()) {
             if (possibleline.counts) {
-              // thirds = this.getThirds(donelinks.concat(maplinks), possibleline.a, possibleline.b);
-              thirds = thisplugin.getThirds2(donelinks, maplinks, possibleline.a, possibleline.b);
+              thirds = thisplugin.getThirds2(donelinks, thisplugin.existingIntelPlanLinks, possibleline.a, possibleline.b);
             }
           } else {
             // thirds = this.getThirds(donelinks, possibleline.a, possibleline.b);


### PR DESCRIPTION
## Summary
- integrate visible existing own-faction Intel links into the field plan when the selected Respect Intel mode includes the player faction
- keep those existing links out of new link/key/AP counts while allowing them to satisfy field prerequisites
- bump userscript/meta version to 2.8.2.20260506 and document the behavior

## Validation
- `node --check iitc_plugin_fanfields2.user.js`
- `git diff --check`
- manual IITC test reported working

Fixes #121