### PR TITLE
Fix ReferenceError: formatDistance is not defined (desktop Task List)

### DIFF
--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.2.20260506
+// @version         2.8.3.20260910
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-05-06-233150';
+  plugin_info.dateTimeVersion = '2026-09-10-133600';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin, formatDistance  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.3',
+      changes: [
+        'FIX: formatDistance is not defined on desktop IITC-CE builds.',
+      ],
+    },{    
       version: '2.8.2',
       changes: [
         'FIX: Respect Intel integrates already existing own-faction links into planned fields.',

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -438,6 +438,21 @@ function wrapper(plugin_info) {
   /* jshint shadow:true */
   window.plugin.fanfields = function () {};
   var thisplugin = window.plugin.fanfields;
+  
+  // Compat: window.formatDistance has been moved to IITC.utils.formatDistance
+  // in the recent builds of IITC-CE (desktop). We handle both cases :
+  thisplugin.formatDistance = function (distance) {
+      if (window.IITC && window.IITC.utils && typeof window.IITC.utils.formatDistance === 'function') {
+          return window.IITC.utils.formatDistance(distance);
+      }
+      if (typeof window.formatDistance === 'function') {
+          return window.formatDistance(distance);
+      }
+      // Fallback minimal si aucune des deux n'existe
+      return distance < 1000
+          ? Math.round(distance) + ' m'
+          : (distance / 1000).toFixed(2) + ' km';
+  };
 
   // const values
   // zoom level used for projecting points between latLng and pixel coordinates. may affect precision of triangulation
@@ -985,7 +1000,7 @@ function wrapper(plugin_info) {
           linkDetailText += '<td></td>';
 
           // Link (Distance)
-          linkDetailText += '<td>' + formatDistance(distance) + '</td>';
+          linkDetailText += '<td>' + thisplugin.formatDistance(distance) + '</td>';
           // Fields
           let fieldsCreatedByThisLink = (meta && meta.fieldsCreatedValid !== undefined) ? meta.fieldsCreatedValid : (meta && meta.creatingFieldsWith ? meta.creatingFieldsWith.length : 0);
 

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -28,7 +28,7 @@ function wrapper(plugin_info) {
   plugin_info.dateTimeVersion = '2026-09-10-133600';
   plugin_info.pluginId = 'fanfields';
 
-  /* global L, $, dialog, map, portals, links, plugin, formatDistance  -- eslint*/
+  /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
   /* exported setup, changelog -- eslint */
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';


### PR DESCRIPTION
### Bug

Opening "Task List" on desktop IITC-CE throws:

    Uncaught ReferenceError: formatDistance is not defined
        at exportText (iitc_plugin_fanfields2.user.js:965)
        at Array.forEach (<anonymous>)
        at exportText (iitc_plugin_fanfields2.user.js:932)
        at Array.forEach (<anonymous>)
        at thisplugin.exportText

The same feature works fine on IITC-CE mobile.

### Root cause

IITC's plugin migration guide documents that `window.formatDistance`
was moved to `IITC.utils.formatDistance`. The old global alias appears
to no longer be reliably exposed on the desktop build being used here,
while the mobile build still provides it — hence the discrepancy
between platforms.

`exportText()` calls the bare global `formatDistance(distance)`,
relying entirely on that alias existing.

### Fix

Introduce `thisplugin.formatDistance()`, a small compatibility wrapper
that:
1. Uses `IITC.utils.formatDistance` when available (current API),
2. Falls back to `window.formatDistance` for older IITC builds,
3. Falls back to a minimal local m/km formatter as a last resort.

`exportText()` now calls `thisplugin.formatDistance(distance)` instead
of the bare global.

### Testing

Verified locally (Tampermonkey override) that Task List no longer
throws and correctly displays link distances on desktop IITC-CE.