### PR TITLE
Highlight already-completed links and portals in the Task List

### DIFF
--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.3.20260910
+// @version         2.8.4.20260912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-10-133600';
+  plugin_info.dateTimeVersion = '2026-09-12-171500';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.4',
+      changes: [
+        'NEW: add button to flip a link.',
+      ],
+    },{         
       version: '2.8.3',
       changes: [
         'FIX: formatDistance is not defined on desktop IITC-CE builds.',
@@ -497,6 +502,11 @@ function wrapper(plugin_info) {
   thisplugin.manualOrderGuids = null;
   thisplugin.lastPlanSignature = null;
 
+  // Manual per-link direction overrides (Task List "flip" button).
+  // Keyed by undirected link key (getUndirectedLinkKey) -> true.
+  // Only applies to mesh links between fan points; the anchor's fan/star links are never flipped this way.
+  thisplugin.manualLinkFlips = {};
+
   thisplugin.saveBookmarks = function () {
 
     // loop thru portals and UN-Select them for bkmrks
@@ -587,8 +597,9 @@ function wrapper(plugin_info) {
     thisplugin.startingpointGUID = thisplugin.perimeterpoints[thisplugin.startingpointIndex][0];
     thisplugin.startingpoint = this.fanpoints[thisplugin.startingpointGUID];
 
-    // Reset manual order because the start/anchor changed (ghi#23)
+    // Reset manual order and link flips because the start/anchor changed (ghi#23)
     thisplugin.manualOrderGuids = null;
+    thisplugin.manualLinkFlips = {};
 
     thisplugin.updateLayer();
   }
@@ -852,11 +863,14 @@ function wrapper(plugin_info) {
 
   // Show as list
   thisplugin.exportText = function () {
+
+    function buildExportHTML() {
     var text = '<table><thead><tr>';
     let fieldSymbol = '&#9650;';
 
     text += '<th style="text-align:right">Pos.</th>';
     text += '<th style="text-align:right">Action</th>';
+    text += '<th style="width:20px;"></th>';
     text += '<th style="text-align:left">Portal Name</th>';
     if (window.plugin.keys || window.plugin.LiveInventory) {
       text += '<th title="own/need">'
@@ -928,11 +942,11 @@ function wrapper(plugin_info) {
 
       text += '<td>';
       text += '  <label class="plugin_fanfields2_exportText_Label" for="plugin_fanfields2_exportText_' + portal.guid + '">Capture</label>';
-      text += '  <input type="checkbox" id="plugin_fanfields2_exportText_' + portal.guid + '" plugin_fanfields2_exportText_toggle="toggle">';
+      text += '  <input type="checkbox" id="plugin_fanfields2_exportText_' + portal.guid + '" data-guid="' + portal.guid + '" plugin_fanfields2_exportText_toggle="toggle">';
       text += '</td>';
 
-
-
+      // Spacer column (aligns with the flip-button column on link detail rows)
+      text += '<td></td>';
 
       // Portal Name
 
@@ -994,6 +1008,18 @@ function wrapper(plugin_info) {
           }
           linkDetailText += '</td>';
 
+          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic).
+          var isAnchorLink = (portal.guid === thisplugin.startingpointGUID) || (outPortal.guid === thisplugin.startingpointGUID);
+          linkDetailText += '<td>';
+          if (!isAnchorLink) {
+            var isFlipped = thisplugin.isLinkFlipped(portal.guid, outPortal.guid);
+            linkDetailText += '<button class="plugin_fanfields2_link_flip_btn' + (isFlipped ? ' plugin_fanfields2_link_flipped' : '') +
+              '" data-guid-a="' + portal.guid + '" data-guid-b="' + outPortal.guid + '" title="' +
+              (isFlipped ? 'Manually flipped – click to restore automatic direction' : 'Reverse link direction (updates keys needed)') +
+              '">&#8646;</button>';
+          }
+          linkDetailText += '</td>';
+
           let outPortalTitle = 'unknown title';
           if (outPortal.portal !== undefined) {
             outPortalTitle = outPortal.portal.options.data.title;
@@ -1026,7 +1052,10 @@ function wrapper(plugin_info) {
     text += '<hr noshade>';
     gmnav += '&nav=1';
 
+    let flipCount = Object.keys(thisplugin.manualLinkFlips || {}).length;
     text += '<div style="margin-top:10px; text-align:right;">' +
+      '  <button id="plugin_fanfields2_reset_link_flips_btn"' + (flipCount === 0 ? ' disabled' : '') +
+      '    title="Revert all manually flipped links (' + flipCount + ') back to automatic calculation">Reset link orders</button> ' +
       '  <button id="plugin_fanfields2_export_pdf_btn">Print</button>' +
       '</div>';
 
@@ -1038,6 +1067,9 @@ function wrapper(plugin_info) {
     text += '<a target="_blank" href="' + gmnav + '">Navigate with Google Maps</a>';
     text += '</div>';
 
+    return text;
+    } // end buildExportHTML
+
     thisplugin.exportDialogWidth = 500;
 
     var width = thisplugin.exportDialogWidth;
@@ -1046,8 +1078,43 @@ function wrapper(plugin_info) {
       width = thisplugin.MaxDialogWidth;
     }
 
-    const toggleFunction = function () {
-      $('[plugin_fanfields2_exportText_toggle="toggle"]')
+    // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
+    // flip/reset refresh doesn't visually collapse the dialog back to its default state.
+    function getExpandedGuids() {
+      var guids = [];
+      $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
+        .each(function () {
+          var guid = $(this).attr('data-guid');
+          if (guid) guids.push(guid);
+        });
+      return guids;
+    }
+
+    function restoreExpandedGuids(guids) {
+      var $inner = $('#plugin_fanfields2_exportText_inner');
+      guids.forEach(function (guid) {
+        var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
+        if (!$toggle.length) return;
+        $toggle.prop('checked', true);
+        $toggle.parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails')
+          .show();
+        $toggle.prev('.plugin_fanfields2_exportText_Label')
+          .attr('aria-expanded', true);
+      });
+    }
+
+    function refreshExportDialog() {
+      var expandedGuids = getExpandedGuids();
+      $('#plugin_fanfields2_exportText_inner').html(buildExportHTML());
+      wireExportHandlers();
+      restoreExpandedGuids(expandedGuids);
+    }
+
+    function wireExportHandlers() {
+      var $inner = $('#plugin_fanfields2_exportText_inner');
+
+      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
         .each(function () {
           const $toggle = $(this);
           const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
@@ -1061,7 +1128,7 @@ function wrapper(plugin_info) {
             $label.css('cursor', 'default'); // Reset the cursor back to default
           }
         });
-      $('[plugin_fanfields2_exportText_toggle="toggle"]')
+      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
         .change(function () {
           const isChecked = $(this)
             .is(':checked');
@@ -1073,31 +1140,49 @@ function wrapper(plugin_info) {
             .prev('.plugin_fanfields2_exportText_Label')
             .attr('aria-expanded', isChecked);
         });
-    };
+
+      // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
+      $inner
+        .off('click.plugin_fanfields2_link_flip')
+        .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
+          ev.preventDefault();
+          var guidA = $(this).attr('data-guid-a');
+          var guidB = $(this).attr('data-guid-b');
+          thisplugin.toggleLinkFlip(guidA, guidB);
+          refreshExportDialog();
+        });
+
+      $('#plugin_fanfields2_reset_link_flips_btn')
+        .off('click')
+        .on('click', function () {
+          thisplugin.resetLinkFlips();
+          refreshExportDialog();
+        });
+
+      $('#plugin_fanfields2_export_pdf_btn')
+        .off('click')
+        .on('click', function () {
+          thisplugin.exportTaskListToPDF();
+        });
+
+      if (thisplugin.isCompatiblePortalRoutePlugin()) {
+        $('#plugin_fanfields2_portal_route_link')
+          .off('click')
+          .on('click', function (ev) {
+            ev.preventDefault();
+            thisplugin.routeWithPortalRoute();
+          });
+      }
+    }
 
     dialog({
-      html: text,
+      html: '<div id="plugin_fanfields2_exportText_inner">' + buildExportHTML() + '</div>',
       id: 'plugin_fanfields2_alert_textExport',
       title: 'Fan Fields 2 - Task List',
       width: width,
       closeOnEscape: true
     });
-    toggleFunction();
-
-    $('#plugin_fanfields2_export_pdf_btn')
-      .off('click')
-      .on('click', function () {
-        thisplugin.exportTaskListToPDF();
-      });
-
-    if (thisplugin.isCompatiblePortalRoutePlugin()) {
-      $('#plugin_fanfields2_portal_route_link')
-        .off('click')
-        .on('click', function (ev) {
-          ev.preventDefault();
-          thisplugin.routeWithPortalRoute();
-        });
-    }
+    wireExportHandlers();
 
   };
 
@@ -1642,8 +1727,9 @@ function wrapper(plugin_info) {
       clockwiseWord = "Counterclockwise";
     }
 
-    // Reset the order – new geometry, new base ordering (ghi#23)
+    // Reset the order and link flips – new geometry, new base ordering (ghi#23)
     thisplugin.manualOrderGuids = null;
+    thisplugin.manualLinkFlips = {};
 
     $('#plugin_fanfields2_clckwsbtn')
       .html(clockwiseWord + '&nbsp;' + clockwiseSymbol + '');
@@ -1894,6 +1980,27 @@ function wrapper(plugin_info) {
       '}\n' +
       '.plugin_fanfields2_exportText_Label.has-children[aria-expanded="true"]::before {\n' +
       '    content: "\\25BF";\n /* (▿) */\n' +
+      '}\n'
+    );
+
+    // Task List: per-link "flip direction" button (ghi#23)
+    addCSS('\n' +
+      '.plugin_fanfields2_link_flip_btn {\n' +
+      '  box-sizing: border-box;\n' +
+      '  padding: 0 2px;\n' +
+      '  border-width: 1px;\n' +
+      '  font-size: 10px;\n' +
+      '  line-height: 1;\n' +
+      '  vertical-align: middle;\n' +
+      '  cursor: pointer;\n' +
+      '}\n' +
+      '.plugin_fanfields2_link_flipped {\n' +
+      '  color: #ffce00;\n' +
+      '  border-color: #ffce00;\n' +
+      '}\n' +
+      '#plugin_fanfields2_reset_link_flips_btn[disabled] {\n' +
+      '  opacity: 0.4;\n' +
+      '  cursor: default;\n' +
       '}\n'
     );
 
@@ -2329,6 +2436,34 @@ function wrapper(plugin_info) {
 
   thisplugin.getUndirectedLinkKey = function (guidA, guidB) {
     return (guidA < guidB) ? (guidA + '|' + guidB) : (guidB + '|' + guidA);
+  };
+
+  // ghi#23 (link flip)
+  // Whether this (undirected) link pair currently has a manual direction override.
+  thisplugin.isLinkFlipped = function (guidA, guidB) {
+    return !!thisplugin.manualLinkFlips[thisplugin.getUndirectedLinkKey(guidA, guidB)];
+  };
+
+  // Toggle the manual direction override for a mesh link (Task List "flip" button).
+  // Anchor links (fan/star links to the starting portal) are never flippable this way.
+  thisplugin.toggleLinkFlip = function (guidA, guidB) {
+    if (!guidA || !guidB) return;
+    if (guidA === thisplugin.startingpointGUID || guidB === thisplugin.startingpointGUID) return;
+
+    var key = thisplugin.getUndirectedLinkKey(guidA, guidB);
+    if (thisplugin.manualLinkFlips[key]) {
+      delete thisplugin.manualLinkFlips[key];
+    } else {
+      thisplugin.manualLinkFlips[key] = true;
+    }
+
+    thisplugin.updateLayer();
+  };
+
+  // Drop all manual link-direction overrides at once (Task List "Reset link orders" button).
+  thisplugin.resetLinkFlips = function () {
+    thisplugin.manualLinkFlips = {};
+    thisplugin.updateLayer();
   };
 
   // Strict point-in-triangle test in projection space:
@@ -2915,12 +3050,16 @@ function wrapper(plugin_info) {
     var currentSignature = fanpointGuids.sort()
       .join(',');
 
-    // If the portal set changed: disable the path
+    // If the portal set changed: disable the path and drop manual link flips (ghi#23),
+    // since they reference GUID pairs that may no longer be part of the plan.
     if (thisplugin.lastPlanSignature !== null &&
-      thisplugin.lastPlanSignature !== currentSignature &&
-      thisplugin.showOrderPath) {
+      thisplugin.lastPlanSignature !== currentSignature) {
 
-      thisplugin.setOrderPathActive(false);
+      thisplugin.manualLinkFlips = {};
+
+      if (thisplugin.showOrderPath) {
+        thisplugin.setOrderPathActive(false);
+      }
     }
 
     // Store signature for the next run
@@ -3253,6 +3392,9 @@ function wrapper(plugin_info) {
         bearing = this.getBearing(a, b);
         const distance = thisplugin.distanceTo(a, b);
 
+        // ghi#23 (link flip): manual direction override for mesh links (never for the anchor's fan/star links).
+        var flipped = (pb !== 0) && thisplugin.isLinkFlipped(this.sortedFanpoints[pa].guid, this.sortedFanpoints[pb].guid);
+
         if (pb === 0) {
           var maxLinks = 8 + thisplugin.availableSBUL * 8;
           if (thisplugin.stardirection === thisplugin.starDirENUM.RADIATING && centerOutgoings < maxLinks) {
@@ -3267,13 +3409,16 @@ function wrapper(plugin_info) {
             // console.log("outbound");
             centerOutgoings++;
           }
+        } else if (flipped) {
+          a = this.sortedFanpoints[pb].point;
+          b = paPoint;
         }
 
         possibleline = {
           a: a,
           b: b,
-          guidA: (outbound === 1) ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
-          guidB: (outbound === 1) ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
+          guidA: (outbound === 1 || flipped) ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
+          guidB: (outbound === 1 || flipped) ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
           bearing: bearing,
           isJetLink: false,
           isFanLink: (pb === 0),
@@ -3369,6 +3514,14 @@ function wrapper(plugin_info) {
                 creatingFieldsWith: possibleline.creatingFieldsWith
               };
 
+            } else if (flipped) {
+              // ghi#23 (link flip): pb is now the source, pa the destination.
+              this.sortedFanpoints[pb].outgoing.push(this.sortedFanpoints[pa]);
+              this.sortedFanpoints[pa].incoming.push(this.sortedFanpoints[pb]);
+
+              this.sortedFanpoints[pb].outgoingMeta[this.sortedFanpoints[pa].guid] = {
+                creatingFieldsWith: possibleline.creatingFieldsWith
+              };
             } else {
               this.sortedFanpoints[pa].outgoing.push(this.sortedFanpoints[pb]);
               this.sortedFanpoints[pb].incoming.push(this.sortedFanpoints[pa]);

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.4.20260912
+// @version         2.8.5.20260912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-12-171500';
+  plugin_info.dateTimeVersion = '2026-09-12-190000';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,11 +33,17 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.5',
+      changes: [
+        'NEW: Task List strikes through a link line already made in-game for your faction (grey), and once all of a portal\'s links exist, fades and strikes through that whole portal line too (yellow). Toggle via the "Grey out done links" button.',
+        'NEW: Task List now refreshes itself live as the background plan changes (new links appearing in-game, fan field rotation, anchor changes, ...) — no need to close and reopen it.',
+      ],
+    },{
       version: '2.8.4',
       changes: [
         'NEW: add button to flip a link.',
       ],
-    },{         
+    },{
       version: '2.8.3',
       changes: [
         'FIX: formatDistance is not defined on desktop IITC-CE builds.',
@@ -861,10 +867,9 @@ function wrapper(plugin_info) {
     });
   };
 
-  // Show as list
-  thisplugin.exportText = function () {
-
-    function buildExportHTML() {
+  // Task List: build the HTML for the current plan. Used both to open the dialog and to
+  // refresh it live (see thisplugin.refreshTaskListIfOpen) as the background plan changes.
+  thisplugin.buildTaskListHTML = function () {
     var text = '<table><thead><tr>';
     let fieldSymbol = '&#9650;';
 
@@ -904,6 +909,13 @@ function wrapper(plugin_info) {
       let title = window.escapeHtmlSpecialChars(rawTitle);
       let uriTitle = encodeURIComponent(rawTitle);
 
+      // All of this portal's outgoing links already exist in-game (own faction)?
+      // If so, the whole portal row is "done": faded out and struck through.
+      let allOutgoingLinksDone = thisplugin.greyOutExistingLinks && portal.outgoing.length > 0 &&
+        portal.outgoing.every(function (outPortal) {
+          return thisplugin.isLinkInGame(portal.guid, outPortal.guid);
+        });
+
       var keysNeeded = (portal.incomingValidCount !== undefined) ? portal.incomingValidCount : portal.incoming.length;
 
       let availableKeysText = '';
@@ -934,7 +946,7 @@ function wrapper(plugin_info) {
         availableKeysText = '>';
       };
       // Row start
-      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr>';
+      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr' + (allOutgoingLinksDone ? ' class="plugin_fanfields2_portal_done"' : '') + '>';
       // List Item Index (Pos.)
       text += '<td>' + (index) + '</td>';
 
@@ -991,8 +1003,11 @@ function wrapper(plugin_info) {
 
           let meta = portal.outgoingMeta?.[outPortal.guid];
 
+          // Link already exists in-game (own faction)? Fade & strike through the whole line.
+          let linkDone = thisplugin.greyOutExistingLinks && thisplugin.isLinkInGame(portal.guid, outPortal.guid);
+
           // Row start
-          let linkDetailText = '<tr>';
+          let linkDetailText = '<tr' + (linkDone ? ' class="plugin_fanfields2_link_done"' : '') + '>';
 
           // List Item Index (Pos.)
           linkDetailText += '<td>' + (index) + '.' + thisplugin.sortedFanpoints.indexOf(outPortal) + '</td>';
@@ -1008,10 +1023,11 @@ function wrapper(plugin_info) {
           }
           linkDetailText += '</td>';
 
-          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic).
+          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic),
+          // as is a link already done in-game (nothing left to flip).
           var isAnchorLink = (portal.guid === thisplugin.startingpointGUID) || (outPortal.guid === thisplugin.startingpointGUID);
           linkDetailText += '<td>';
-          if (!isAnchorLink) {
+          if (!isAnchorLink && !linkDone) {
             var isFlipped = thisplugin.isLinkFlipped(portal.guid, outPortal.guid);
             linkDetailText += '<button class="plugin_fanfields2_link_flip_btn' + (isFlipped ? ' plugin_fanfields2_link_flipped' : '') +
               '" data-guid-a="' + portal.guid + '" data-guid-b="' + outPortal.guid + '" title="' +
@@ -1068,8 +1084,125 @@ function wrapper(plugin_info) {
     text += '</div>';
 
     return text;
-    } // end buildExportHTML
+  }; // end buildTaskListHTML
 
+  // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
+  // refresh (flip/reset, or a live background update) doesn't visually collapse the
+  // dialog back to its default state.
+  thisplugin.getTaskListExpandedGuids = function () {
+    var guids = [];
+    $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
+      .each(function () {
+        var guid = $(this).attr('data-guid');
+        if (guid) guids.push(guid);
+      });
+    return guids;
+  };
+
+  thisplugin.restoreTaskListExpandedGuids = function (guids) {
+    var $inner = $('#plugin_fanfields2_exportText_inner');
+    guids.forEach(function (guid) {
+      var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
+      if (!$toggle.length) return;
+      $toggle.prop('checked', true);
+      $toggle.parents()
+        .next('.plugin_fanfields2_exportText_LinkDetails')
+        .show();
+      $toggle.prev('.plugin_fanfields2_exportText_Label')
+        .attr('aria-expanded', true);
+    });
+  };
+
+  // Rebuild the Task List dialog's content in place, preserving the expanded/collapsed
+  // per-portal link lists. Used after a flip/reset, and to auto-refresh live as the
+  // background plan changes (new links appearing in-game, fan field rotation, etc.).
+  thisplugin.refreshTaskListDialog = function () {
+    var expandedGuids = thisplugin.getTaskListExpandedGuids();
+    $('#plugin_fanfields2_exportText_inner').html(thisplugin.buildTaskListHTML());
+    thisplugin.wireTaskListHandlers();
+    thisplugin.restoreTaskListExpandedGuids(expandedGuids);
+  };
+
+  // Whether the Task List dialog is currently open and visible.
+  thisplugin.isTaskListDialogOpen = function () {
+    return $('#plugin_fanfields2_exportText_inner').is(':visible');
+  };
+
+  // Called after every plan recalculation (see updateLayer) so an open Task List reflects
+  // background changes — new links appearing in-game, fan field rotation, etc. — without
+  // the user having to close and reopen it.
+  thisplugin.refreshTaskListIfOpen = function () {
+    if (thisplugin.isTaskListDialogOpen()) {
+      thisplugin.refreshTaskListDialog();
+    }
+  };
+
+  thisplugin.wireTaskListHandlers = function () {
+    var $inner = $('#plugin_fanfields2_exportText_inner');
+
+    $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
+      .each(function () {
+        const $toggle = $(this);
+        const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
+        const $details = $toggle.parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails');
+
+        if ($details.length) {
+          $label.addClass('has-children');
+        } else {
+          $toggle.remove(); // Remove the checkbox if there are no child elements
+          $label.css('cursor', 'default'); // Reset the cursor back to default
+        }
+      });
+    $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
+      .change(function () {
+        const isChecked = $(this)
+          .is(':checked');
+        $(this)
+          .parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails')
+          .toggle();
+        $(this)
+          .prev('.plugin_fanfields2_exportText_Label')
+          .attr('aria-expanded', isChecked);
+      });
+
+    // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
+    $inner
+      .off('click.plugin_fanfields2_link_flip')
+      .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
+        ev.preventDefault();
+        var guidA = $(this).attr('data-guid-a');
+        var guidB = $(this).attr('data-guid-b');
+        thisplugin.toggleLinkFlip(guidA, guidB);
+        thisplugin.refreshTaskListDialog();
+      });
+
+    $('#plugin_fanfields2_reset_link_flips_btn')
+      .off('click')
+      .on('click', function () {
+        thisplugin.resetLinkFlips();
+        thisplugin.refreshTaskListDialog();
+      });
+
+    $('#plugin_fanfields2_export_pdf_btn')
+      .off('click')
+      .on('click', function () {
+        thisplugin.exportTaskListToPDF();
+      });
+
+    if (thisplugin.isCompatiblePortalRoutePlugin()) {
+      $('#plugin_fanfields2_portal_route_link')
+        .off('click')
+        .on('click', function (ev) {
+          ev.preventDefault();
+          thisplugin.routeWithPortalRoute();
+        });
+    }
+  };
+
+  // Show as list
+  thisplugin.exportText = function () {
     thisplugin.exportDialogWidth = 500;
 
     var width = thisplugin.exportDialogWidth;
@@ -1078,111 +1211,14 @@ function wrapper(plugin_info) {
       width = thisplugin.MaxDialogWidth;
     }
 
-    // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
-    // flip/reset refresh doesn't visually collapse the dialog back to its default state.
-    function getExpandedGuids() {
-      var guids = [];
-      $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
-        .each(function () {
-          var guid = $(this).attr('data-guid');
-          if (guid) guids.push(guid);
-        });
-      return guids;
-    }
-
-    function restoreExpandedGuids(guids) {
-      var $inner = $('#plugin_fanfields2_exportText_inner');
-      guids.forEach(function (guid) {
-        var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
-        if (!$toggle.length) return;
-        $toggle.prop('checked', true);
-        $toggle.parents()
-          .next('.plugin_fanfields2_exportText_LinkDetails')
-          .show();
-        $toggle.prev('.plugin_fanfields2_exportText_Label')
-          .attr('aria-expanded', true);
-      });
-    }
-
-    function refreshExportDialog() {
-      var expandedGuids = getExpandedGuids();
-      $('#plugin_fanfields2_exportText_inner').html(buildExportHTML());
-      wireExportHandlers();
-      restoreExpandedGuids(expandedGuids);
-    }
-
-    function wireExportHandlers() {
-      var $inner = $('#plugin_fanfields2_exportText_inner');
-
-      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
-        .each(function () {
-          const $toggle = $(this);
-          const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
-          const $details = $toggle.parents()
-            .next('.plugin_fanfields2_exportText_LinkDetails');
-
-          if ($details.length) {
-            $label.addClass('has-children');
-          } else {
-            $toggle.remove(); // Remove the checkbox if there are no child elements
-            $label.css('cursor', 'default'); // Reset the cursor back to default
-          }
-        });
-      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
-        .change(function () {
-          const isChecked = $(this)
-            .is(':checked');
-          $(this)
-            .parents()
-            .next('.plugin_fanfields2_exportText_LinkDetails')
-            .toggle();
-          $(this)
-            .prev('.plugin_fanfields2_exportText_Label')
-            .attr('aria-expanded', isChecked);
-        });
-
-      // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
-      $inner
-        .off('click.plugin_fanfields2_link_flip')
-        .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
-          ev.preventDefault();
-          var guidA = $(this).attr('data-guid-a');
-          var guidB = $(this).attr('data-guid-b');
-          thisplugin.toggleLinkFlip(guidA, guidB);
-          refreshExportDialog();
-        });
-
-      $('#plugin_fanfields2_reset_link_flips_btn')
-        .off('click')
-        .on('click', function () {
-          thisplugin.resetLinkFlips();
-          refreshExportDialog();
-        });
-
-      $('#plugin_fanfields2_export_pdf_btn')
-        .off('click')
-        .on('click', function () {
-          thisplugin.exportTaskListToPDF();
-        });
-
-      if (thisplugin.isCompatiblePortalRoutePlugin()) {
-        $('#plugin_fanfields2_portal_route_link')
-          .off('click')
-          .on('click', function (ev) {
-            ev.preventDefault();
-            thisplugin.routeWithPortalRoute();
-          });
-      }
-    }
-
     dialog({
-      html: '<div id="plugin_fanfields2_exportText_inner">' + buildExportHTML() + '</div>',
+      html: '<div id="plugin_fanfields2_exportText_inner">' + thisplugin.buildTaskListHTML() + '</div>',
       id: 'plugin_fanfields2_alert_textExport',
       title: 'Fan Fields 2 - Task List',
       width: width,
       closeOnEscape: true
     });
-    wireExportHandlers();
+    thisplugin.wireTaskListHandlers();
 
   };
 
@@ -1249,6 +1285,18 @@ function wrapper(plugin_info) {
           td[plugin_fanfields2_enoughKeys],
           div[plugin_fanfields2_enoughKeys] {
             color: #828284;
+          }
+
+          tr.plugin_fanfields2_portal_done,
+          tr.plugin_fanfields2_portal_done td,
+          tr.plugin_fanfields2_portal_done a,
+          tr.plugin_fanfields2_portal_done span,
+          tr.plugin_fanfields2_link_done,
+          tr.plugin_fanfields2_link_done td,
+          tr.plugin_fanfields2_link_done a,
+          tr.plugin_fanfields2_link_done span {
+            color: #828284 !important;
+            text-decoration: line-through !important;
           }
         `;
 
@@ -1684,6 +1732,19 @@ function wrapper(plugin_info) {
     thisplugin.delayedUpdateLayer(0.2);
   };
 
+  // Task List: grey out / strike through links (and, once all of a portal's
+  // links exist, the portal name too) that already exist in-game for the
+  // player's own faction. Requested as a toggleable plugin option.
+  thisplugin.greyOutExistingLinks = true;
+  thisplugin.toggleGreyOutExistingLinks = function () {
+    thisplugin.greyOutExistingLinks = !thisplugin.greyOutExistingLinks;
+    thisplugin.updateGreyOutExistingLinksButton();
+  };
+  thisplugin.updateGreyOutExistingLinksButton = function () {
+    $('#plugin_fanfields2_greyout_existing_btn')
+      .html('Grey&nbsp;out&nbsp;done&nbsp;links:&nbsp;' + (thisplugin.greyOutExistingLinks ? 'ON' : 'OFF'));
+  };
+
   thisplugin.is_locked = false;
   thisplugin.lock = function () {
     thisplugin.is_locked = !thisplugin.is_locked;
@@ -2004,6 +2065,30 @@ function wrapper(plugin_info) {
       '}\n'
     );
 
+    // Task List: once all of a portal's links exist in-game, the whole portal
+    // line fades from bright to pale yellow and is struck through, end to end.
+    addCSS('\n' +
+      'tr.plugin_fanfields2_portal_done,\n' +
+      'tr.plugin_fanfields2_portal_done td,\n' +
+      'tr.plugin_fanfields2_portal_done a,\n' +
+      'tr.plugin_fanfields2_portal_done span {\n' +
+      '  color: rgba(255, 206, 0, 0.35) !important;\n' +
+      '  text-decoration: line-through !important;\n' +
+      '}\n'
+    );
+
+    // Task List: a link line that already exists in-game stays grey (like the
+    // rest of the link details) but gets struck through, end to end.
+    addCSS('\n' +
+      'tr.plugin_fanfields2_link_done,\n' +
+      'tr.plugin_fanfields2_link_done td,\n' +
+      'tr.plugin_fanfields2_link_done a,\n' +
+      'tr.plugin_fanfields2_link_done span {\n' +
+      '  color: #828284 !important;\n' +
+      '  text-decoration: line-through !important;\n' +
+      '}\n'
+    );
+
 
     addCSS('\n' +
       '.plugin_fanfields2_label {\n' +
@@ -2228,6 +2313,26 @@ function wrapper(plugin_info) {
     if ((Aa || Ab) && (Ba || Bb)) {
       return true;
     }
+  };
+
+  // Task List: does a real in-game link already exist between these two portals?
+  // Only links belonging to the player's own faction count (Res links must not
+  // grey out an Enl plan, and vice versa).
+  thisplugin.isLinkInGame = function (guidA, guidB) {
+    var ownTeam = thisplugin.getOwnFactionTeam();
+    if (ownTeam === undefined) return false;
+
+    var pointA = thisplugin.locations && thisplugin.locations[guidA];
+    var pointB = thisplugin.locations && thisplugin.locations[guidB];
+    if (!pointA || !pointB) return false;
+
+    var testLink = { a: pointA, b: pointB };
+    for (var guid in thisplugin.intelLinks) {
+      var link = thisplugin.intelLinks[guid];
+      if (link.team !== ownTeam) continue;
+      if (thisplugin.linksEqual(link, testLink)) return true;
+    }
+    return false;
   };
 
 
@@ -3640,6 +3745,10 @@ function wrapper(plugin_info) {
     } else if (thisplugin.orderPathLayerGroup) {
       thisplugin.orderPathLayerGroup.clearLayers();
     }
+
+    // Keep an open Task List in sync with the background plan (new links appearing
+    // in-game, fan field rotation, etc.) without requiring it to be reopened.
+    thisplugin.refreshTaskListIfOpen();
   };
 
 
@@ -3788,6 +3897,10 @@ function wrapper(plugin_info) {
     var buttonLinkDirectionIndicator =
       '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_direction_indicator_btn" onclick="window.plugin.fanfields.toggleLinkDirIndicator();" title="Technology Intelligence See All">Show&nbsp;link&nbsp;dir:&nbsp;ON</a> ';
 
+    // Task List: grey out / strike through links (and finished portals) that already exist in-game
+    var buttonGreyOutExistingLinks =
+      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_greyout_existing_btn" onclick="window.plugin.fanfields.toggleGreyOutExistingLinks();" title="Grey out and strike through Task List links (and portals) that already exist in-game for your faction">Grey&nbsp;out&nbsp;done&nbsp;links:&nbsp;ON</a> ';
+
     // Shift anchor
     var buttonShiftAnchor =
       '<a class="plugin_fanfields2_btn" onclick="window.plugin.fanfields.previousStartingPoint();" title="Less Chaos More Stability">Shift&nbsp;left&nbsp;' +
@@ -3822,6 +3935,7 @@ function wrapper(plugin_info) {
       buttonRespect +
       buttonBookmarksOnly +
       buttonLinkDirectionIndicator +
+      buttonGreyOutExistingLinks +
       buttonPortalList +
       buttonManageOrder +
       buttonDrawTools +
@@ -3863,6 +3977,7 @@ function wrapper(plugin_info) {
       .append(fanfields_buttons);
 
     thisplugin.updateRespectIntelButton();
+    thisplugin.updateGreyOutExistingLinksButton();
 
     //         window.pluginCreateHook('pluginBkmrksEdit');
 


### PR DESCRIPTION
The Task List now marks work that's already done in-game for your faction:

- A link that's already made is struck through, in grey.
- Once every link from a portal is already made, that portal's whole line fades to a pale yellow and is struck through too.
- The flip-direction button is hidden for a link that's already done, since there's nothing left to flip.
- This can be toggled on/off from a new "Grey out done links" button in the toolbar.

The Task List also keeps itself up to date automatically while it's open: if a new link appears on the map, the fan field rotates, the anchor portal changes, or anything else about the plan updates in the background, the list reflects it right away, with no need to close and reopen the window.

<img width="501" height="677" alt="image" src="https://github.com/user-attachments/assets/d8a6004f-b734-489d-a8b7-b4bff0ea1cc1" />
