### PR TITLE
Optim: reorient links for fewer keys or less walking

### DIFF
--- a/iitc_plugin_fanfields2.meta.js
+++ b/iitc_plugin_fanfields2.meta.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.3.20260910
+// @version         2.8.7.20260913
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -548,21 +548,14 @@ function wrapper(plugin_info) {
   // KEYS: greedy rebalancing of mesh link direction to lower the maximum keys needed at any
   //       single portal.
   // DISTANCE: when a portal's own OUTGOING count (as the base algorithm computed it — not its
-  //           total degree) is exactly 2 — its anchor link plus one mesh link, the only two
-  //           things it would ever need to physically throw — its mesh link flips (mesh
-  //           partner -> portal) only if that partner is just as close, or closer, to
+  //           total degree) is exactly 2 — its anchor link plus one mesh link — its mesh link
+  //           flips (mesh partner -> portal) if that partner is just as close, or closer, to
   //           whatever comes right after this portal in the walk: i.e. this portal wasn't
-  //           really "on the way". Rather than also flipping its anchor link (which would cost
-  //           an anchor outgoing slot for no real benefit), the portal is instead relocated in
-  //           the WALK/DISPLAY order only (thisplugin.displayOrderGuids — see above): among
-  //           every consecutive pair in the whole walk (not just near the mesh partner above,
-  //           which was picked for field-geometry reasons and can sit far away), it's inserted
-  //           between whichever pair minimizes the added detour (cheapest insertion), so it
-  //           lands genuinely on the way between two portals already walked back-to-back —
-  //           wherever those happen to be. Its anchor link then throws normally (portal ->
-  //           anchor) since that's no longer a costly detour either. Other portals throwing
-  //           INTO it later doesn't disqualify it either way — those links exist regardless and
-  //           never required it to do anything.
+  //           really "on the way". Rather than also flipping its anchor link, the portal is
+  //           instead relocated in the WALK/DISPLAY order only (thisplugin.displayOrderGuids —
+  //           see above), to wherever in the whole walk adds the least extra distance
+  //           (cheapest insertion), while never landing after a portal that throws a link at
+  //           it — see computeDistanceOrderReordering for the details.
   // ALGO ("Algorithm", no automatic override) still exists internally as the target of a full
   // "Reset link orders" (Task List), but the menu button no longer cycles through it — it
   // toggles only between KEYS and DISTANCE, which default to DISTANCE ("Less walking").
@@ -3099,38 +3092,20 @@ function wrapper(plugin_info) {
     return { incomingCount: incomingCount, invalidCount: invalidCount };
   };
 
-  // "Less walking": what matters is a portal's own OUTGOING count as the base algorithm
-  // computed it — not its total degree. A portal that other portals also happen to throw
-  // links AT (later, "from outside") is unaffected by any of this: those incoming links exist
-  // regardless and never require this portal to do anything.
+  // "Less walking": a portal whose own OUTGOING count is exactly 2 (its anchor link plus one
+  // mesh link) is a candidate. Its mesh link flips to point AT it (mesh partner -> portal)
+  // when that partner is just as close, or closer, to whatever comes right after this portal
+  // in the walk — i.e. this portal wasn't really "on the way", so the partner can throw
+  // straight to the next stop instead. A portal with outgoing count 1 or 3+ is left untouched.
   //
-  // A portal with exactly 2 outgoing links (its anchor link + one mesh link) is a CANDIDATE,
-  // but its mesh link only actually flips when the portal isn't really "on the way": comparing
-  // its mesh partner P to this portal (D1 = distance(P, portal)) against P to whatever comes
-  // right after this portal in the walk (D2 = distance(P, next)) — if D2 < D1, going straight
-  // from P to the next stop is no farther than the current detour through this portal, so P
-  // can throw to it instead and the walk skips the extra stop-and-throw here. If D2 >= D1, the
-  // portal genuinely sits on the way to the next stop, so its mesh link is left alone.
-  // Rather than also flipping the anchor link (which would spend an anchor outgoing slot just
-  // to dodge a walking detour), the portal is instead relocated in the WALK/DISPLAY order only
+  // Once flipped, the portal is relocated in the WALK/DISPLAY order only
   // (thisplugin.displayOrderGuids — see computeDistanceOrderReordering), never in
-  // thisplugin.sortedFanpoints itself: the core algorithm only ever considers, for each
-  // portal, the portals that precede it in sortedFanpoints as link partners, so reordering
-  // that array would silently change which links/fields exist — exactly what this feature must
-  // never do. The relocation target has nothing to do with the mesh partner picked above (that
-  // partner was chosen by the base algorithm for field-geometry reasons, and can easily sit far
-  // away): the portal is dropped wherever in the CURRENT walk — anywhere, not just next to its
-  // partner — adds the least extra distance, exactly like a step of the classic "cheapest
-  // insertion" TSP heuristic. This only changes where the portal shows up in the Task List,
-  // on-map position numbers, the "Path" preview, navigation, and bookmarks — every link still
-  // exists between the exact same two portals, in whichever direction the flips above settled
-  // on. Relocated portals are recorded in thisplugin.relocatedForLessWalkingGuids purely so the
-  // Task List can flag them: since they're no longer visited in their "natural" position, they
-  // must already be captured — with enough of their own keys gathered — by the time the walk
-  // reaches that earlier spot.
-  // A portal whose own outgoing count is 1 (just its anchor link) or 3+ is left untouched —
-  // the latter is a nested-field hub whose link order the algorithm depends on, where the
-  // extra walking is unavoidable.
+  // thisplugin.sortedFanpoints: the core algorithm builds links/fields from that array, so
+  // reordering it would change the plan itself, not just how it's walked. Its anchor link then
+  // throws normally, and relocated portals are recorded in
+  // thisplugin.relocatedForLessWalkingGuids so the Task List can flag them (green): since
+  // they're no longer visited in their "natural" position, they must already be captured —
+  // with enough of their own keys gathered — by the time the walk reaches that earlier spot.
   thisplugin.computeDistanceOrderFlips = function () {
     var edges = thisplugin.buildLinkOrderEdges();
     var naturalByKey = thisplugin.getNaturalMeshDirections(edges);
@@ -3154,9 +3129,7 @@ function wrapper(plugin_info) {
 
     var current = edges.map(function (e) { return $.extend({}, e); });
 
-    // Portals whose mesh link actually flips below — these are the ones relocated further
-    // down. Reordering (computeDistanceOrderReordering) doesn't care which partner a relocated
-    // portal ended up with; it just finds the cheapest spot for it in the whole walk.
+    // Portals whose mesh link actually flips below — these are the ones relocated further down.
     var meshFlippedGuids = {};
 
     // Mesh links: only the current thrower can qualify (its own 2 outgoing links are the fan
@@ -3191,24 +3164,14 @@ function wrapper(plugin_info) {
     var flips = thisplugin.flipsFromDirections(current, naturalByKey);
 
     // Every portal that throws a link AT a given guid, in the final (post-flip) direction —
-    // not just its flipped mesh link: a relocated portal can also receive an ordinary,
-    // never-touched incoming link from some unrelated portal (e.g. two different portals both
-    // happen to link to the same fan point), and whoever throws needs it already captured
-    // either way. computeDistanceOrderReordering uses this as a hard "must come before" bound
-    // — capturing it, and farming enough of its own keys, is only possible once it's actually
-    // been visited, so it can never be walked to AFTER something that throws to it.
+    // used by computeDistanceOrderReordering so a relocated portal never lands in the walk
+    // after something that needs it already captured.
     var incomingSourcesByGuid = {};
     current.forEach(function (e) {
       (incomingSourcesByGuid[e.dstGuid] = incomingSourcesByGuid[e.dstGuid] || []).push(e.srcGuid);
     });
 
-    // Relocate each flipped portal to wherever in the walk adds the least extra distance —
-    // not necessarily next to its mesh partner, which was picked by the base algorithm for
-    // field-geometry reasons and can sit far away geographically. Its anchor link is left
-    // alone (natural direction) — it's no longer a costly detour once relocated. This only
-    // ever writes to thisplugin.displayOrderGuids (a pure display/walk order), never to
-    // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids (the Manage Portal Order
-    // feature's own, unrelated, BUILD-order override) — see thisplugin.getDisplayOrder().
+    // Relocate each flipped portal into the walk/display order.
     var reorderResult = thisplugin.computeDistanceOrderReordering(meshFlippedGuids, incomingSourcesByGuid);
     if (reorderResult) {
       thisplugin.displayOrderGuids = reorderResult.order;
@@ -3222,29 +3185,16 @@ function wrapper(plugin_info) {
   };
 
   // For each guid in relocateGuids, inserts it wherever in the current walk minimizes the
-  // extra distance added — a "cheapest insertion" step (classic TSP heuristic), not
-  // necessarily anywhere near the mesh partner that made it a candidate in the first place:
-  // that partner was chosen by the base algorithm for field-geometry reasons and can easily
-  // sit far away, while the portal itself may in fact be geographically embedded among
-  // completely different, unrelated portals — that's exactly where it belongs when walking.
-  // Every gap between two consecutive portals in the walk is a candidate — EXCEPT any gap at
-  // or past the earliest portal in incomingSourcesByGuid[guid] (whoever throws a link at this
-  // one, be it the flipped mesh link or an ordinary link the base algorithm never touched):
-  // that source needs this portal already captured, with enough of its own keys farmed, so it
-  // can never land later in the walk than every one of its sources — it must be visited in
-  // time, not just cheaply. Among the remaining, earlier gaps (plus appending after the last
-  // stop, when nothing constrains it at all), the one whose two endpoints are least stretched
-  // by detouring through this portal wins. Relocated portals are processed one at a time, in
-  // thisplugin.sortedFanpoints order, and each insertion updates the walk before the next
-  // portal is placed — so a portal relocated earlier in this same pass can itself become part
-  // of a later portal's cheapest gap (e.g. two portals that belong together end up next to
-  // each other) and can itself act as a "source" bound for one relocated later. This is purely
-  // a DISPLAY/WALK reorder: the returned order is only ever meant for
-  // thisplugin.displayOrderGuids, and must never be applied to thisplugin.sortedFanpoints or
-  // thisplugin.manualOrderGuids — the core algorithm only considers, for each portal, the
-  // portals preceding it in sortedFanpoints as link partners, so reordering that array (rather
-  // than just how it's walked/displayed) would silently change which links/fields the
-  // algorithm produces, not just their direction.
+  // extra distance added ("cheapest insertion", a classic TSP heuristic) — anywhere in the
+  // walk, not just next to the mesh partner that made it a candidate. The only restriction: it
+  // must land strictly before every portal in incomingSourcesByGuid[guid] (whoever throws a
+  // link at it), since it needs to already be captured, with enough of its own keys farmed, by
+  // then. Relocated portals are processed one at a time, in thisplugin.sortedFanpoints order,
+  // each insertion updating the walk before the next portal is placed, so two portals that
+  // belong together can end up next to each other. This is purely a DISPLAY/WALK reorder: the
+  // returned order is only ever meant for thisplugin.displayOrderGuids, never applied to
+  // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids — the core algorithm decides
+  // which links/fields exist from sortedFanpoints alone.
   // Returns null if nothing moved, or { order: <full guid order, anchor first>, movedGuids:
   // <guid -> true, only for portals actually relocated> }.
   thisplugin.computeDistanceOrderReordering = function (relocateGuids, incomingSourcesByGuid) {
@@ -3279,13 +3229,13 @@ function wrapper(plugin_info) {
         if (srcIdx !== -1 && srcIdx < limit) limit = srcIdx;
       });
 
-      // Try every gap in the walk so far (between order[i] and order[i+1]) that still ends
-      // before `limit`, plus appending after the last stop when nothing bounds it at all —
-      // and keep whichever adds the least distance.
+      // Try every gap in the walk so far (between order[i] and order[i+1]) that keeps this
+      // portal before `limit`, plus appending after the last stop when nothing bounds it — and
+      // keep whichever adds the least distance.
       var bestIdx = -1;
       var bestCost = Infinity;
 
-      var maxGapStart = Math.min(order.length - 2, limit - 2);
+      var maxGapStart = Math.min(order.length - 2, limit - 1);
       for (var i = 0; i <= maxGapStart; i++) {
         var a = order[i], b = order[i + 1];
         var cost = dist(a, fp.guid) + dist(fp.guid, b) - dist(a, b);
@@ -3296,12 +3246,11 @@ function wrapper(plugin_info) {
         var lastCost = dist(order[order.length - 1], fp.guid);
         if (lastCost < bestCost) { bestCost = lastCost; bestIdx = order.length - 1; }
       } else if (bestIdx === -1 && limit >= 1) {
-        // No interior gap qualified (the earliest source sits right after the anchor) — the
-        // only spot left that still comes before it is right after the anchor itself.
+        // Earliest source sits right after the anchor — the only spot before it.
         bestIdx = 0;
       }
 
-      if (bestIdx === -1) return; // no valid spot at all (shouldn't normally happen), skip
+      if (bestIdx === -1) return; // no valid spot at all, skip
 
       order.splice(bestIdx + 1, 0, fp.guid);
       movedGuids[fp.guid] = true;

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -553,14 +553,16 @@ function wrapper(plugin_info) {
   //           partner -> portal) only if that partner is just as close, or closer, to
   //           whatever comes right after this portal in the walk: i.e. this portal wasn't
   //           really "on the way". Rather than also flipping its anchor link (which would cost
-  //           an anchor outgoing slot for no real benefit), the portal is instead relocated
-  //           earlier in the WALK/DISPLAY order only (thisplugin.displayOrderGuids — see above):
-  //           among every consecutive pair of preceding portals, it's inserted between whichever
-  //           pair minimizes the added detour (cheapest insertion), so it lands genuinely on the
-  //           way between two portals already walked back-to-back. Its anchor link then throws
-  //           normally (portal -> anchor) since that's no longer a costly detour either. Other
-  //           portals throwing INTO it later doesn't disqualify it either way — those links
-  //           exist regardless and never required it to do anything.
+  //           an anchor outgoing slot for no real benefit), the portal is instead relocated in
+  //           the WALK/DISPLAY order only (thisplugin.displayOrderGuids — see above): among
+  //           every consecutive pair in the whole walk (not just near the mesh partner above,
+  //           which was picked for field-geometry reasons and can sit far away), it's inserted
+  //           between whichever pair minimizes the added detour (cheapest insertion), so it
+  //           lands genuinely on the way between two portals already walked back-to-back —
+  //           wherever those happen to be. Its anchor link then throws normally (portal ->
+  //           anchor) since that's no longer a costly detour either. Other portals throwing
+  //           INTO it later doesn't disqualify it either way — those links exist regardless and
+  //           never required it to do anything.
   // ALGO ("Algorithm", no automatic override) still exists internally as the target of a full
   // "Reset link orders" (Task List), but the menu button no longer cycles through it — it
   // toggles only between KEYS and DISTANCE, which default to DISTANCE ("Less walking").
@@ -3110,18 +3112,22 @@ function wrapper(plugin_info) {
   // can throw to it instead and the walk skips the extra stop-and-throw here. If D2 >= D1, the
   // portal genuinely sits on the way to the next stop, so its mesh link is left alone.
   // Rather than also flipping the anchor link (which would spend an anchor outgoing slot just
-  // to dodge a walking detour), the portal is instead relocated earlier in the WALK/DISPLAY
-  // order only (thisplugin.displayOrderGuids — see computeDistanceOrderReordering), never in
+  // to dodge a walking detour), the portal is instead relocated in the WALK/DISPLAY order only
+  // (thisplugin.displayOrderGuids — see computeDistanceOrderReordering), never in
   // thisplugin.sortedFanpoints itself: the core algorithm only ever considers, for each
   // portal, the portals that precede it in sortedFanpoints as link partners, so reordering
   // that array would silently change which links/fields exist — exactly what this feature must
-  // never do. The relocation only changes where the portal shows up in the Task List, on-map
-  // position numbers, the "Path" preview, navigation, and bookmarks — so it becomes a cheap,
-  // natural detour to WALK there, while every link keeps existing between the exact same two
-  // portals, in whichever direction the flips above settled on. Relocated portals are recorded
-  // in thisplugin.relocatedForLessWalkingGuids purely so the Task List can flag them: since
-  // they're no longer visited in their "natural" position, they must already be captured —
-  // with enough of their own keys gathered — by the time the walk reaches that earlier spot.
+  // never do. The relocation target has nothing to do with the mesh partner picked above (that
+  // partner was chosen by the base algorithm for field-geometry reasons, and can easily sit far
+  // away): the portal is dropped wherever in the CURRENT walk — anywhere, not just next to its
+  // partner — adds the least extra distance, exactly like a step of the classic "cheapest
+  // insertion" TSP heuristic. This only changes where the portal shows up in the Task List,
+  // on-map position numbers, the "Path" preview, navigation, and bookmarks — every link still
+  // exists between the exact same two portals, in whichever direction the flips above settled
+  // on. Relocated portals are recorded in thisplugin.relocatedForLessWalkingGuids purely so the
+  // Task List can flag them: since they're no longer visited in their "natural" position, they
+  // must already be captured — with enough of their own keys gathered — by the time the walk
+  // reaches that earlier spot.
   // A portal whose own outgoing count is 1 (just its anchor link) or 3+ is left untouched —
   // the latter is a nested-field hub whose link order the algorithm depends on, where the
   // extra walking is unavoidable.
@@ -3149,7 +3155,8 @@ function wrapper(plugin_info) {
     var current = edges.map(function (e) { return $.extend({}, e); });
 
     // Portals whose mesh link actually flips below — these are the ones relocated further
-    // down instead of also having their anchor link flipped.
+    // down. Reordering (computeDistanceOrderReordering) doesn't care which partner a relocated
+    // portal ended up with; it just finds the cheapest spot for it in the whole walk.
     var meshFlippedGuids = {};
 
     // Mesh links: only the current thrower can qualify (its own 2 outgoing links are the fan
@@ -3183,8 +3190,9 @@ function wrapper(plugin_info) {
 
     var flips = thisplugin.flipsFromDirections(current, naturalByKey);
 
-    // Relocate each portal whose mesh link flipped: right after whichever preceding portal
-    // (by current walk position) is geographically closest to it. Its anchor link is left
+    // Relocate each flipped portal to wherever in the walk adds the least extra distance —
+    // not necessarily next to its mesh partner, which was picked by the base algorithm for
+    // field-geometry reasons and can sit far away geographically. Its anchor link is left
     // alone (natural direction) — it's no longer a costly detour once relocated. This only
     // ever writes to thisplugin.displayOrderGuids (a pure display/walk order), never to
     // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids (the Manage Portal Order
@@ -3201,39 +3209,40 @@ function wrapper(plugin_info) {
     return flips;
   };
 
-  // For each guid in relocateGuids, finds the cheapest place to insert it among the portals
-  // that precede it in the current walk (thisplugin.sortedFanpoints) — not simply the closest
-  // single predecessor, but the best EDGE to split: among every consecutive pair (A, B) of
-  // preceding, non-relocated portals, the one minimizing dist(A, P) + dist(P, B) - dist(A, B)
-  // (the classic "cheapest insertion" heuristic) — so the portal lands genuinely on the way
-  // between two portals already walked back-to-back, not just near whichever single portal
-  // happens to be nearest (which could be a dead end). Only non-relocated portals are valid
-  // edge endpoints — chaining relocated portals off one another would make the result depend
-  // on processing order. This is purely a DISPLAY/WALK reorder: the returned order is only
-  // ever meant for thisplugin.displayOrderGuids, and must never be applied to
-  // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids — the core algorithm only
-  // considers, for each portal, the portals preceding it in sortedFanpoints as link partners,
-  // so reordering that array (rather than just how it's walked/displayed) would silently
-  // change which links/fields the algorithm produces, not just their direction. Returns null
-  // if nothing moved, or { order: <full guid order, anchor first>, movedGuids: <guid -> true,
-  // only for portals actually relocated> }.
+  // For each guid in relocateGuids, inserts it wherever in the current walk minimizes the
+  // extra distance added — a "cheapest insertion" step (classic TSP heuristic), not
+  // necessarily anywhere near the mesh partner that made it a candidate in the first place:
+  // that partner was chosen by the base algorithm for field-geometry reasons and can easily
+  // sit far away, while the portal itself may in fact be geographically embedded among
+  // completely different, unrelated portals — that's exactly where it belongs when walking.
+  // Every gap between two consecutive portals in the walk is a candidate (plus appending after
+  // the last one); the gap whose two endpoints are least stretched by detouring through this
+  // portal wins. Relocated portals are processed one at a time, in thisplugin.sortedFanpoints
+  // order, and each insertion updates the walk before the next portal is placed — so a portal
+  // relocated earlier in this same pass can itself become part of a later portal's cheapest
+  // gap (e.g. two portals that belong together end up next to each other), but the search
+  // itself is otherwise global: nothing pins a portal to its own partner. This is purely a
+  // DISPLAY/WALK reorder: the returned order is only ever meant for
+  // thisplugin.displayOrderGuids, and must never be applied to thisplugin.sortedFanpoints or
+  // thisplugin.manualOrderGuids — the core algorithm only considers, for each portal, the
+  // portals preceding it in sortedFanpoints as link partners, so reordering that array (rather
+  // than just how it's walked/displayed) would silently change which links/fields the
+  // algorithm produces, not just their direction.
+  // Returns null if nothing moved, or { order: <full guid order, anchor first>, movedGuids:
+  // <guid -> true, only for portals actually relocated> }.
   thisplugin.computeDistanceOrderReordering = function (relocateGuids) {
     var sorted = thisplugin.sortedFanpoints || [];
     if (!sorted.length) return null;
 
-    var indexByGuid = {};
     var pointByGuid = {};
-    sorted.forEach(function (fp, idx) {
-      indexByGuid[fp.guid] = idx;
-      pointByGuid[fp.guid] = fp.point;
-    });
+    sorted.forEach(function (fp) { pointByGuid[fp.guid] = fp.point; });
 
     function dist(guidA, guidB) {
       return thisplugin.distanceTo(pointByGuid[guidA], pointByGuid[guidB]);
     }
 
-    // Everyone NOT being relocated, kept in their original relative order — the stable
-    // backbone the relocated portals get inserted into.
+    // Everyone NOT being relocated, kept in their original relative order — the starting
+    // walk that relocated portals get inserted into, one at a time.
     var order = sorted
       .filter(function (fp) { return !relocateGuids[fp.guid]; })
       .map(function (fp) { return fp.guid; });
@@ -3243,32 +3252,23 @@ function wrapper(plugin_info) {
     sorted.forEach(function (fp) {
       if (!relocateGuids[fp.guid]) return;
 
-      var idx = indexByGuid[fp.guid];
-
-      // Non-relocated portals that precede fp in the ORIGINAL order, in their relative order —
-      // the only valid edge endpoints ("AVANT son emplacement actuel").
-      var precedingGuids = [];
-      for (var j = 0; j < idx; j++) {
-        if (!relocateGuids[sorted[j].guid]) precedingGuids.push(sorted[j].guid);
-      }
-      if (precedingGuids.length < 2) return; // no edge to split (e.g. right after the anchor)
-
-      var bestA = null;
+      // Try every gap in the walk so far (between order[i] and order[i+1]), plus appending
+      // after the last stop, and keep whichever adds the least distance.
+      var bestIdx = -1;
       var bestCost = Infinity;
 
-      for (var e = 0; e < precedingGuids.length - 1; e++) {
-        var A = precedingGuids[e];
-        var B = precedingGuids[e + 1];
-        var cost = dist(A, fp.guid) + dist(fp.guid, B) - dist(A, B);
-        if (cost < bestCost) {
-          bestCost = cost;
-          bestA = A;
-        }
+      for (var i = 0; i < order.length - 1; i++) {
+        var a = order[i], b = order[i + 1];
+        var cost = dist(a, fp.guid) + dist(fp.guid, b) - dist(a, b);
+        if (cost < bestCost) { bestCost = cost; bestIdx = i; }
       }
 
-      if (bestA === null) return;
+      var lastCost = dist(order[order.length - 1], fp.guid);
+      if (lastCost < bestCost) { bestCost = lastCost; bestIdx = order.length - 1; }
 
-      order.splice(order.indexOf(bestA) + 1, 0, fp.guid);
+      if (bestIdx === -1) return; // empty order (shouldn't normally happen), skip
+
+      order.splice(bestIdx + 1, 0, fp.guid);
       movedGuids[fp.guid] = true;
     });
 

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.3.20260910
+// @version         2.8.4.20260912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-10-133600';
+  plugin_info.dateTimeVersion = '2026-09-12-171500';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.4',
+      changes: [
+        'NEW: add button to flip a link.',
+      ],
+    },{         
       version: '2.8.3',
       changes: [
         'FIX: formatDistance is not defined on desktop IITC-CE builds.',
@@ -497,6 +502,11 @@ function wrapper(plugin_info) {
   thisplugin.manualOrderGuids = null;
   thisplugin.lastPlanSignature = null;
 
+  // Manual per-link direction overrides (Task List "flip" button).
+  // Keyed by undirected link key (getUndirectedLinkKey) -> true.
+  // Only applies to mesh links between fan points; the anchor's fan/star links are never flipped this way.
+  thisplugin.manualLinkFlips = {};
+
   thisplugin.saveBookmarks = function () {
 
     // loop thru portals and UN-Select them for bkmrks
@@ -587,8 +597,9 @@ function wrapper(plugin_info) {
     thisplugin.startingpointGUID = thisplugin.perimeterpoints[thisplugin.startingpointIndex][0];
     thisplugin.startingpoint = this.fanpoints[thisplugin.startingpointGUID];
 
-    // Reset manual order because the start/anchor changed (ghi#23)
+    // Reset manual order and link flips because the start/anchor changed (ghi#23)
     thisplugin.manualOrderGuids = null;
+    thisplugin.manualLinkFlips = {};
 
     thisplugin.updateLayer();
   }
@@ -852,11 +863,14 @@ function wrapper(plugin_info) {
 
   // Show as list
   thisplugin.exportText = function () {
+
+    function buildExportHTML() {
     var text = '<table><thead><tr>';
     let fieldSymbol = '&#9650;';
 
     text += '<th style="text-align:right">Pos.</th>';
     text += '<th style="text-align:right">Action</th>';
+    text += '<th style="width:20px;"></th>';
     text += '<th style="text-align:left">Portal Name</th>';
     if (window.plugin.keys || window.plugin.LiveInventory) {
       text += '<th title="own/need">'
@@ -928,11 +942,11 @@ function wrapper(plugin_info) {
 
       text += '<td>';
       text += '  <label class="plugin_fanfields2_exportText_Label" for="plugin_fanfields2_exportText_' + portal.guid + '">Capture</label>';
-      text += '  <input type="checkbox" id="plugin_fanfields2_exportText_' + portal.guid + '" plugin_fanfields2_exportText_toggle="toggle">';
+      text += '  <input type="checkbox" id="plugin_fanfields2_exportText_' + portal.guid + '" data-guid="' + portal.guid + '" plugin_fanfields2_exportText_toggle="toggle">';
       text += '</td>';
 
-
-
+      // Spacer column (aligns with the flip-button column on link detail rows)
+      text += '<td></td>';
 
       // Portal Name
 
@@ -994,6 +1008,18 @@ function wrapper(plugin_info) {
           }
           linkDetailText += '</td>';
 
+          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic).
+          var isAnchorLink = (portal.guid === thisplugin.startingpointGUID) || (outPortal.guid === thisplugin.startingpointGUID);
+          linkDetailText += '<td>';
+          if (!isAnchorLink) {
+            var isFlipped = thisplugin.isLinkFlipped(portal.guid, outPortal.guid);
+            linkDetailText += '<button class="plugin_fanfields2_link_flip_btn' + (isFlipped ? ' plugin_fanfields2_link_flipped' : '') +
+              '" data-guid-a="' + portal.guid + '" data-guid-b="' + outPortal.guid + '" title="' +
+              (isFlipped ? 'Manually flipped – click to restore automatic direction' : 'Reverse link direction (updates keys needed)') +
+              '">&#8646;</button>';
+          }
+          linkDetailText += '</td>';
+
           let outPortalTitle = 'unknown title';
           if (outPortal.portal !== undefined) {
             outPortalTitle = outPortal.portal.options.data.title;
@@ -1026,7 +1052,10 @@ function wrapper(plugin_info) {
     text += '<hr noshade>';
     gmnav += '&nav=1';
 
+    let flipCount = Object.keys(thisplugin.manualLinkFlips || {}).length;
     text += '<div style="margin-top:10px; text-align:right;">' +
+      '  <button id="plugin_fanfields2_reset_link_flips_btn"' + (flipCount === 0 ? ' disabled' : '') +
+      '    title="Revert all manually flipped links (' + flipCount + ') back to automatic calculation">Reset link orders</button> ' +
       '  <button id="plugin_fanfields2_export_pdf_btn">Print</button>' +
       '</div>';
 
@@ -1038,6 +1067,9 @@ function wrapper(plugin_info) {
     text += '<a target="_blank" href="' + gmnav + '">Navigate with Google Maps</a>';
     text += '</div>';
 
+    return text;
+    } // end buildExportHTML
+
     thisplugin.exportDialogWidth = 500;
 
     var width = thisplugin.exportDialogWidth;
@@ -1046,8 +1078,43 @@ function wrapper(plugin_info) {
       width = thisplugin.MaxDialogWidth;
     }
 
-    const toggleFunction = function () {
-      $('[plugin_fanfields2_exportText_toggle="toggle"]')
+    // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
+    // flip/reset refresh doesn't visually collapse the dialog back to its default state.
+    function getExpandedGuids() {
+      var guids = [];
+      $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
+        .each(function () {
+          var guid = $(this).attr('data-guid');
+          if (guid) guids.push(guid);
+        });
+      return guids;
+    }
+
+    function restoreExpandedGuids(guids) {
+      var $inner = $('#plugin_fanfields2_exportText_inner');
+      guids.forEach(function (guid) {
+        var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
+        if (!$toggle.length) return;
+        $toggle.prop('checked', true);
+        $toggle.parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails')
+          .show();
+        $toggle.prev('.plugin_fanfields2_exportText_Label')
+          .attr('aria-expanded', true);
+      });
+    }
+
+    function refreshExportDialog() {
+      var expandedGuids = getExpandedGuids();
+      $('#plugin_fanfields2_exportText_inner').html(buildExportHTML());
+      wireExportHandlers();
+      restoreExpandedGuids(expandedGuids);
+    }
+
+    function wireExportHandlers() {
+      var $inner = $('#plugin_fanfields2_exportText_inner');
+
+      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
         .each(function () {
           const $toggle = $(this);
           const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
@@ -1061,7 +1128,7 @@ function wrapper(plugin_info) {
             $label.css('cursor', 'default'); // Reset the cursor back to default
           }
         });
-      $('[plugin_fanfields2_exportText_toggle="toggle"]')
+      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
         .change(function () {
           const isChecked = $(this)
             .is(':checked');
@@ -1073,31 +1140,49 @@ function wrapper(plugin_info) {
             .prev('.plugin_fanfields2_exportText_Label')
             .attr('aria-expanded', isChecked);
         });
-    };
+
+      // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
+      $inner
+        .off('click.plugin_fanfields2_link_flip')
+        .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
+          ev.preventDefault();
+          var guidA = $(this).attr('data-guid-a');
+          var guidB = $(this).attr('data-guid-b');
+          thisplugin.toggleLinkFlip(guidA, guidB);
+          refreshExportDialog();
+        });
+
+      $('#plugin_fanfields2_reset_link_flips_btn')
+        .off('click')
+        .on('click', function () {
+          thisplugin.resetLinkFlips();
+          refreshExportDialog();
+        });
+
+      $('#plugin_fanfields2_export_pdf_btn')
+        .off('click')
+        .on('click', function () {
+          thisplugin.exportTaskListToPDF();
+        });
+
+      if (thisplugin.isCompatiblePortalRoutePlugin()) {
+        $('#plugin_fanfields2_portal_route_link')
+          .off('click')
+          .on('click', function (ev) {
+            ev.preventDefault();
+            thisplugin.routeWithPortalRoute();
+          });
+      }
+    }
 
     dialog({
-      html: text,
+      html: '<div id="plugin_fanfields2_exportText_inner">' + buildExportHTML() + '</div>',
       id: 'plugin_fanfields2_alert_textExport',
       title: 'Fan Fields 2 - Task List',
       width: width,
       closeOnEscape: true
     });
-    toggleFunction();
-
-    $('#plugin_fanfields2_export_pdf_btn')
-      .off('click')
-      .on('click', function () {
-        thisplugin.exportTaskListToPDF();
-      });
-
-    if (thisplugin.isCompatiblePortalRoutePlugin()) {
-      $('#plugin_fanfields2_portal_route_link')
-        .off('click')
-        .on('click', function (ev) {
-          ev.preventDefault();
-          thisplugin.routeWithPortalRoute();
-        });
-    }
+    wireExportHandlers();
 
   };
 
@@ -1642,8 +1727,9 @@ function wrapper(plugin_info) {
       clockwiseWord = "Counterclockwise";
     }
 
-    // Reset the order – new geometry, new base ordering (ghi#23)
+    // Reset the order and link flips – new geometry, new base ordering (ghi#23)
     thisplugin.manualOrderGuids = null;
+    thisplugin.manualLinkFlips = {};
 
     $('#plugin_fanfields2_clckwsbtn')
       .html(clockwiseWord + '&nbsp;' + clockwiseSymbol + '');
@@ -1894,6 +1980,27 @@ function wrapper(plugin_info) {
       '}\n' +
       '.plugin_fanfields2_exportText_Label.has-children[aria-expanded="true"]::before {\n' +
       '    content: "\\25BF";\n /* (▿) */\n' +
+      '}\n'
+    );
+
+    // Task List: per-link "flip direction" button (ghi#23)
+    addCSS('\n' +
+      '.plugin_fanfields2_link_flip_btn {\n' +
+      '  box-sizing: border-box;\n' +
+      '  padding: 0 2px;\n' +
+      '  border-width: 1px;\n' +
+      '  font-size: 10px;\n' +
+      '  line-height: 1;\n' +
+      '  vertical-align: middle;\n' +
+      '  cursor: pointer;\n' +
+      '}\n' +
+      '.plugin_fanfields2_link_flipped {\n' +
+      '  color: #ffce00;\n' +
+      '  border-color: #ffce00;\n' +
+      '}\n' +
+      '#plugin_fanfields2_reset_link_flips_btn[disabled] {\n' +
+      '  opacity: 0.4;\n' +
+      '  cursor: default;\n' +
       '}\n'
     );
 
@@ -2329,6 +2436,34 @@ function wrapper(plugin_info) {
 
   thisplugin.getUndirectedLinkKey = function (guidA, guidB) {
     return (guidA < guidB) ? (guidA + '|' + guidB) : (guidB + '|' + guidA);
+  };
+
+  // ghi#23 (link flip)
+  // Whether this (undirected) link pair currently has a manual direction override.
+  thisplugin.isLinkFlipped = function (guidA, guidB) {
+    return !!thisplugin.manualLinkFlips[thisplugin.getUndirectedLinkKey(guidA, guidB)];
+  };
+
+  // Toggle the manual direction override for a mesh link (Task List "flip" button).
+  // Anchor links (fan/star links to the starting portal) are never flippable this way.
+  thisplugin.toggleLinkFlip = function (guidA, guidB) {
+    if (!guidA || !guidB) return;
+    if (guidA === thisplugin.startingpointGUID || guidB === thisplugin.startingpointGUID) return;
+
+    var key = thisplugin.getUndirectedLinkKey(guidA, guidB);
+    if (thisplugin.manualLinkFlips[key]) {
+      delete thisplugin.manualLinkFlips[key];
+    } else {
+      thisplugin.manualLinkFlips[key] = true;
+    }
+
+    thisplugin.updateLayer();
+  };
+
+  // Drop all manual link-direction overrides at once (Task List "Reset link orders" button).
+  thisplugin.resetLinkFlips = function () {
+    thisplugin.manualLinkFlips = {};
+    thisplugin.updateLayer();
   };
 
   // Strict point-in-triangle test in projection space:
@@ -2915,12 +3050,16 @@ function wrapper(plugin_info) {
     var currentSignature = fanpointGuids.sort()
       .join(',');
 
-    // If the portal set changed: disable the path
+    // If the portal set changed: disable the path and drop manual link flips (ghi#23),
+    // since they reference GUID pairs that may no longer be part of the plan.
     if (thisplugin.lastPlanSignature !== null &&
-      thisplugin.lastPlanSignature !== currentSignature &&
-      thisplugin.showOrderPath) {
+      thisplugin.lastPlanSignature !== currentSignature) {
 
-      thisplugin.setOrderPathActive(false);
+      thisplugin.manualLinkFlips = {};
+
+      if (thisplugin.showOrderPath) {
+        thisplugin.setOrderPathActive(false);
+      }
     }
 
     // Store signature for the next run
@@ -3253,6 +3392,9 @@ function wrapper(plugin_info) {
         bearing = this.getBearing(a, b);
         const distance = thisplugin.distanceTo(a, b);
 
+        // ghi#23 (link flip): manual direction override for mesh links (never for the anchor's fan/star links).
+        var flipped = (pb !== 0) && thisplugin.isLinkFlipped(this.sortedFanpoints[pa].guid, this.sortedFanpoints[pb].guid);
+
         if (pb === 0) {
           var maxLinks = 8 + thisplugin.availableSBUL * 8;
           if (thisplugin.stardirection === thisplugin.starDirENUM.RADIATING && centerOutgoings < maxLinks) {
@@ -3267,13 +3409,16 @@ function wrapper(plugin_info) {
             // console.log("outbound");
             centerOutgoings++;
           }
+        } else if (flipped) {
+          a = this.sortedFanpoints[pb].point;
+          b = paPoint;
         }
 
         possibleline = {
           a: a,
           b: b,
-          guidA: (outbound === 1) ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
-          guidB: (outbound === 1) ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
+          guidA: (outbound === 1 || flipped) ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
+          guidB: (outbound === 1 || flipped) ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
           bearing: bearing,
           isJetLink: false,
           isFanLink: (pb === 0),
@@ -3369,6 +3514,14 @@ function wrapper(plugin_info) {
                 creatingFieldsWith: possibleline.creatingFieldsWith
               };
 
+            } else if (flipped) {
+              // ghi#23 (link flip): pb is now the source, pa the destination.
+              this.sortedFanpoints[pb].outgoing.push(this.sortedFanpoints[pa]);
+              this.sortedFanpoints[pa].incoming.push(this.sortedFanpoints[pb]);
+
+              this.sortedFanpoints[pb].outgoingMeta[this.sortedFanpoints[pa].guid] = {
+                creatingFieldsWith: possibleline.creatingFieldsWith
+              };
             } else {
               this.sortedFanpoints[pa].outgoing.push(this.sortedFanpoints[pb]);
               this.sortedFanpoints[pb].incoming.push(this.sortedFanpoints[pa]);

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.4.20260912
+// @version         2.8.5.20260912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-12-171500';
+  plugin_info.dateTimeVersion = '2026-09-12-190000';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,11 +33,17 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.5',
+      changes: [
+        'NEW: Task List strikes through a link line already made in-game for your faction (grey), and once all of a portal\'s links exist, fades and strikes through that whole portal line too (yellow). Toggle via the "Grey out done links" button.',
+        'NEW: Task List now refreshes itself live as the background plan changes (new links appearing in-game, fan field rotation, anchor changes, ...) — no need to close and reopen it.',
+      ],
+    },{
       version: '2.8.4',
       changes: [
         'NEW: add button to flip a link.',
       ],
-    },{         
+    },{
       version: '2.8.3',
       changes: [
         'FIX: formatDistance is not defined on desktop IITC-CE builds.',
@@ -861,10 +867,9 @@ function wrapper(plugin_info) {
     });
   };
 
-  // Show as list
-  thisplugin.exportText = function () {
-
-    function buildExportHTML() {
+  // Task List: build the HTML for the current plan. Used both to open the dialog and to
+  // refresh it live (see thisplugin.refreshTaskListIfOpen) as the background plan changes.
+  thisplugin.buildTaskListHTML = function () {
     var text = '<table><thead><tr>';
     let fieldSymbol = '&#9650;';
 
@@ -904,6 +909,13 @@ function wrapper(plugin_info) {
       let title = window.escapeHtmlSpecialChars(rawTitle);
       let uriTitle = encodeURIComponent(rawTitle);
 
+      // All of this portal's outgoing links already exist in-game (own faction)?
+      // If so, the whole portal row is "done": faded out and struck through.
+      let allOutgoingLinksDone = thisplugin.greyOutExistingLinks && portal.outgoing.length > 0 &&
+        portal.outgoing.every(function (outPortal) {
+          return thisplugin.isLinkInGame(portal.guid, outPortal.guid);
+        });
+
       var keysNeeded = (portal.incomingValidCount !== undefined) ? portal.incomingValidCount : portal.incoming.length;
 
       let availableKeysText = '';
@@ -934,7 +946,7 @@ function wrapper(plugin_info) {
         availableKeysText = '>';
       };
       // Row start
-      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr>';
+      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr' + (allOutgoingLinksDone ? ' class="plugin_fanfields2_portal_done"' : '') + '>';
       // List Item Index (Pos.)
       text += '<td>' + (index) + '</td>';
 
@@ -991,8 +1003,11 @@ function wrapper(plugin_info) {
 
           let meta = portal.outgoingMeta?.[outPortal.guid];
 
+          // Link already exists in-game (own faction)? Fade & strike through the whole line.
+          let linkDone = thisplugin.greyOutExistingLinks && thisplugin.isLinkInGame(portal.guid, outPortal.guid);
+
           // Row start
-          let linkDetailText = '<tr>';
+          let linkDetailText = '<tr' + (linkDone ? ' class="plugin_fanfields2_link_done"' : '') + '>';
 
           // List Item Index (Pos.)
           linkDetailText += '<td>' + (index) + '.' + thisplugin.sortedFanpoints.indexOf(outPortal) + '</td>';
@@ -1008,10 +1023,11 @@ function wrapper(plugin_info) {
           }
           linkDetailText += '</td>';
 
-          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic).
+          // ghi#23 (link flip): swap this link's direction, in its own compact column. Anchor links are excluded (star/fan logic),
+          // as is a link already done in-game (nothing left to flip).
           var isAnchorLink = (portal.guid === thisplugin.startingpointGUID) || (outPortal.guid === thisplugin.startingpointGUID);
           linkDetailText += '<td>';
-          if (!isAnchorLink) {
+          if (!isAnchorLink && !linkDone) {
             var isFlipped = thisplugin.isLinkFlipped(portal.guid, outPortal.guid);
             linkDetailText += '<button class="plugin_fanfields2_link_flip_btn' + (isFlipped ? ' plugin_fanfields2_link_flipped' : '') +
               '" data-guid-a="' + portal.guid + '" data-guid-b="' + outPortal.guid + '" title="' +
@@ -1068,8 +1084,125 @@ function wrapper(plugin_info) {
     text += '</div>';
 
     return text;
-    } // end buildExportHTML
+  }; // end buildTaskListHTML
 
+  // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
+  // refresh (flip/reset, or a live background update) doesn't visually collapse the
+  // dialog back to its default state.
+  thisplugin.getTaskListExpandedGuids = function () {
+    var guids = [];
+    $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
+      .each(function () {
+        var guid = $(this).attr('data-guid');
+        if (guid) guids.push(guid);
+      });
+    return guids;
+  };
+
+  thisplugin.restoreTaskListExpandedGuids = function (guids) {
+    var $inner = $('#plugin_fanfields2_exportText_inner');
+    guids.forEach(function (guid) {
+      var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
+      if (!$toggle.length) return;
+      $toggle.prop('checked', true);
+      $toggle.parents()
+        .next('.plugin_fanfields2_exportText_LinkDetails')
+        .show();
+      $toggle.prev('.plugin_fanfields2_exportText_Label')
+        .attr('aria-expanded', true);
+    });
+  };
+
+  // Rebuild the Task List dialog's content in place, preserving the expanded/collapsed
+  // per-portal link lists. Used after a flip/reset, and to auto-refresh live as the
+  // background plan changes (new links appearing in-game, fan field rotation, etc.).
+  thisplugin.refreshTaskListDialog = function () {
+    var expandedGuids = thisplugin.getTaskListExpandedGuids();
+    $('#plugin_fanfields2_exportText_inner').html(thisplugin.buildTaskListHTML());
+    thisplugin.wireTaskListHandlers();
+    thisplugin.restoreTaskListExpandedGuids(expandedGuids);
+  };
+
+  // Whether the Task List dialog is currently open and visible.
+  thisplugin.isTaskListDialogOpen = function () {
+    return $('#plugin_fanfields2_exportText_inner').is(':visible');
+  };
+
+  // Called after every plan recalculation (see updateLayer) so an open Task List reflects
+  // background changes — new links appearing in-game, fan field rotation, etc. — without
+  // the user having to close and reopen it.
+  thisplugin.refreshTaskListIfOpen = function () {
+    if (thisplugin.isTaskListDialogOpen()) {
+      thisplugin.refreshTaskListDialog();
+    }
+  };
+
+  thisplugin.wireTaskListHandlers = function () {
+    var $inner = $('#plugin_fanfields2_exportText_inner');
+
+    $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
+      .each(function () {
+        const $toggle = $(this);
+        const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
+        const $details = $toggle.parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails');
+
+        if ($details.length) {
+          $label.addClass('has-children');
+        } else {
+          $toggle.remove(); // Remove the checkbox if there are no child elements
+          $label.css('cursor', 'default'); // Reset the cursor back to default
+        }
+      });
+    $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
+      .change(function () {
+        const isChecked = $(this)
+          .is(':checked');
+        $(this)
+          .parents()
+          .next('.plugin_fanfields2_exportText_LinkDetails')
+          .toggle();
+        $(this)
+          .prev('.plugin_fanfields2_exportText_Label')
+          .attr('aria-expanded', isChecked);
+      });
+
+    // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
+    $inner
+      .off('click.plugin_fanfields2_link_flip')
+      .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
+        ev.preventDefault();
+        var guidA = $(this).attr('data-guid-a');
+        var guidB = $(this).attr('data-guid-b');
+        thisplugin.toggleLinkFlip(guidA, guidB);
+        thisplugin.refreshTaskListDialog();
+      });
+
+    $('#plugin_fanfields2_reset_link_flips_btn')
+      .off('click')
+      .on('click', function () {
+        thisplugin.resetLinkFlips();
+        thisplugin.refreshTaskListDialog();
+      });
+
+    $('#plugin_fanfields2_export_pdf_btn')
+      .off('click')
+      .on('click', function () {
+        thisplugin.exportTaskListToPDF();
+      });
+
+    if (thisplugin.isCompatiblePortalRoutePlugin()) {
+      $('#plugin_fanfields2_portal_route_link')
+        .off('click')
+        .on('click', function (ev) {
+          ev.preventDefault();
+          thisplugin.routeWithPortalRoute();
+        });
+    }
+  };
+
+  // Show as list
+  thisplugin.exportText = function () {
     thisplugin.exportDialogWidth = 500;
 
     var width = thisplugin.exportDialogWidth;
@@ -1078,111 +1211,14 @@ function wrapper(plugin_info) {
       width = thisplugin.MaxDialogWidth;
     }
 
-    // ghi#23 (link flip): remember which portals' link-detail lists are expanded, so a
-    // flip/reset refresh doesn't visually collapse the dialog back to its default state.
-    function getExpandedGuids() {
-      var guids = [];
-      $('#plugin_fanfields2_exportText_inner [plugin_fanfields2_exportText_toggle="toggle"]:checked')
-        .each(function () {
-          var guid = $(this).attr('data-guid');
-          if (guid) guids.push(guid);
-        });
-      return guids;
-    }
-
-    function restoreExpandedGuids(guids) {
-      var $inner = $('#plugin_fanfields2_exportText_inner');
-      guids.forEach(function (guid) {
-        var $toggle = $inner.find('[plugin_fanfields2_exportText_toggle="toggle"][data-guid="' + guid + '"]');
-        if (!$toggle.length) return;
-        $toggle.prop('checked', true);
-        $toggle.parents()
-          .next('.plugin_fanfields2_exportText_LinkDetails')
-          .show();
-        $toggle.prev('.plugin_fanfields2_exportText_Label')
-          .attr('aria-expanded', true);
-      });
-    }
-
-    function refreshExportDialog() {
-      var expandedGuids = getExpandedGuids();
-      $('#plugin_fanfields2_exportText_inner').html(buildExportHTML());
-      wireExportHandlers();
-      restoreExpandedGuids(expandedGuids);
-    }
-
-    function wireExportHandlers() {
-      var $inner = $('#plugin_fanfields2_exportText_inner');
-
-      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
-        .each(function () {
-          const $toggle = $(this);
-          const $label = $toggle.prev('.plugin_fanfields2_exportText_Label');
-          const $details = $toggle.parents()
-            .next('.plugin_fanfields2_exportText_LinkDetails');
-
-          if ($details.length) {
-            $label.addClass('has-children');
-          } else {
-            $toggle.remove(); // Remove the checkbox if there are no child elements
-            $label.css('cursor', 'default'); // Reset the cursor back to default
-          }
-        });
-      $inner.find('[plugin_fanfields2_exportText_toggle="toggle"]')
-        .change(function () {
-          const isChecked = $(this)
-            .is(':checked');
-          $(this)
-            .parents()
-            .next('.plugin_fanfields2_exportText_LinkDetails')
-            .toggle();
-          $(this)
-            .prev('.plugin_fanfields2_exportText_Label')
-            .attr('aria-expanded', isChecked);
-        });
-
-      // ghi#23 (link flip): reverse a link's direction, recompute the plan, and refresh this dialog in place.
-      $inner
-        .off('click.plugin_fanfields2_link_flip')
-        .on('click.plugin_fanfields2_link_flip', '.plugin_fanfields2_link_flip_btn', function (ev) {
-          ev.preventDefault();
-          var guidA = $(this).attr('data-guid-a');
-          var guidB = $(this).attr('data-guid-b');
-          thisplugin.toggleLinkFlip(guidA, guidB);
-          refreshExportDialog();
-        });
-
-      $('#plugin_fanfields2_reset_link_flips_btn')
-        .off('click')
-        .on('click', function () {
-          thisplugin.resetLinkFlips();
-          refreshExportDialog();
-        });
-
-      $('#plugin_fanfields2_export_pdf_btn')
-        .off('click')
-        .on('click', function () {
-          thisplugin.exportTaskListToPDF();
-        });
-
-      if (thisplugin.isCompatiblePortalRoutePlugin()) {
-        $('#plugin_fanfields2_portal_route_link')
-          .off('click')
-          .on('click', function (ev) {
-            ev.preventDefault();
-            thisplugin.routeWithPortalRoute();
-          });
-      }
-    }
-
     dialog({
-      html: '<div id="plugin_fanfields2_exportText_inner">' + buildExportHTML() + '</div>',
+      html: '<div id="plugin_fanfields2_exportText_inner">' + thisplugin.buildTaskListHTML() + '</div>',
       id: 'plugin_fanfields2_alert_textExport',
       title: 'Fan Fields 2 - Task List',
       width: width,
       closeOnEscape: true
     });
-    wireExportHandlers();
+    thisplugin.wireTaskListHandlers();
 
   };
 
@@ -1249,6 +1285,18 @@ function wrapper(plugin_info) {
           td[plugin_fanfields2_enoughKeys],
           div[plugin_fanfields2_enoughKeys] {
             color: #828284;
+          }
+
+          tr.plugin_fanfields2_portal_done,
+          tr.plugin_fanfields2_portal_done td,
+          tr.plugin_fanfields2_portal_done a,
+          tr.plugin_fanfields2_portal_done span,
+          tr.plugin_fanfields2_link_done,
+          tr.plugin_fanfields2_link_done td,
+          tr.plugin_fanfields2_link_done a,
+          tr.plugin_fanfields2_link_done span {
+            color: #828284 !important;
+            text-decoration: line-through !important;
           }
         `;
 
@@ -1684,6 +1732,19 @@ function wrapper(plugin_info) {
     thisplugin.delayedUpdateLayer(0.2);
   };
 
+  // Task List: grey out / strike through links (and, once all of a portal's
+  // links exist, the portal name too) that already exist in-game for the
+  // player's own faction. Requested as a toggleable plugin option.
+  thisplugin.greyOutExistingLinks = true;
+  thisplugin.toggleGreyOutExistingLinks = function () {
+    thisplugin.greyOutExistingLinks = !thisplugin.greyOutExistingLinks;
+    thisplugin.updateGreyOutExistingLinksButton();
+  };
+  thisplugin.updateGreyOutExistingLinksButton = function () {
+    $('#plugin_fanfields2_greyout_existing_btn')
+      .html('Grey&nbsp;out&nbsp;done&nbsp;links:&nbsp;' + (thisplugin.greyOutExistingLinks ? 'ON' : 'OFF'));
+  };
+
   thisplugin.is_locked = false;
   thisplugin.lock = function () {
     thisplugin.is_locked = !thisplugin.is_locked;
@@ -2004,6 +2065,30 @@ function wrapper(plugin_info) {
       '}\n'
     );
 
+    // Task List: once all of a portal's links exist in-game, the whole portal
+    // line fades from bright to pale yellow and is struck through, end to end.
+    addCSS('\n' +
+      'tr.plugin_fanfields2_portal_done,\n' +
+      'tr.plugin_fanfields2_portal_done td,\n' +
+      'tr.plugin_fanfields2_portal_done a,\n' +
+      'tr.plugin_fanfields2_portal_done span {\n' +
+      '  color: rgba(255, 206, 0, 0.35) !important;\n' +
+      '  text-decoration: line-through !important;\n' +
+      '}\n'
+    );
+
+    // Task List: a link line that already exists in-game stays grey (like the
+    // rest of the link details) but gets struck through, end to end.
+    addCSS('\n' +
+      'tr.plugin_fanfields2_link_done,\n' +
+      'tr.plugin_fanfields2_link_done td,\n' +
+      'tr.plugin_fanfields2_link_done a,\n' +
+      'tr.plugin_fanfields2_link_done span {\n' +
+      '  color: #828284 !important;\n' +
+      '  text-decoration: line-through !important;\n' +
+      '}\n'
+    );
+
 
     addCSS('\n' +
       '.plugin_fanfields2_label {\n' +
@@ -2228,6 +2313,26 @@ function wrapper(plugin_info) {
     if ((Aa || Ab) && (Ba || Bb)) {
       return true;
     }
+  };
+
+  // Task List: does a real in-game link already exist between these two portals?
+  // Only links belonging to the player's own faction count (Res links must not
+  // grey out an Enl plan, and vice versa).
+  thisplugin.isLinkInGame = function (guidA, guidB) {
+    var ownTeam = thisplugin.getOwnFactionTeam();
+    if (ownTeam === undefined) return false;
+
+    var pointA = thisplugin.locations && thisplugin.locations[guidA];
+    var pointB = thisplugin.locations && thisplugin.locations[guidB];
+    if (!pointA || !pointB) return false;
+
+    var testLink = { a: pointA, b: pointB };
+    for (var guid in thisplugin.intelLinks) {
+      var link = thisplugin.intelLinks[guid];
+      if (link.team !== ownTeam) continue;
+      if (thisplugin.linksEqual(link, testLink)) return true;
+    }
+    return false;
   };
 
 
@@ -3640,6 +3745,10 @@ function wrapper(plugin_info) {
     } else if (thisplugin.orderPathLayerGroup) {
       thisplugin.orderPathLayerGroup.clearLayers();
     }
+
+    // Keep an open Task List in sync with the background plan (new links appearing
+    // in-game, fan field rotation, etc.) without requiring it to be reopened.
+    thisplugin.refreshTaskListIfOpen();
   };
 
 
@@ -3788,6 +3897,10 @@ function wrapper(plugin_info) {
     var buttonLinkDirectionIndicator =
       '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_direction_indicator_btn" onclick="window.plugin.fanfields.toggleLinkDirIndicator();" title="Technology Intelligence See All">Show&nbsp;link&nbsp;dir:&nbsp;ON</a> ';
 
+    // Task List: grey out / strike through links (and finished portals) that already exist in-game
+    var buttonGreyOutExistingLinks =
+      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_greyout_existing_btn" onclick="window.plugin.fanfields.toggleGreyOutExistingLinks();" title="Grey out and strike through Task List links (and portals) that already exist in-game for your faction">Grey&nbsp;out&nbsp;done&nbsp;links:&nbsp;ON</a> ';
+
     // Shift anchor
     var buttonShiftAnchor =
       '<a class="plugin_fanfields2_btn" onclick="window.plugin.fanfields.previousStartingPoint();" title="Less Chaos More Stability">Shift&nbsp;left&nbsp;' +
@@ -3822,6 +3935,7 @@ function wrapper(plugin_info) {
       buttonRespect +
       buttonBookmarksOnly +
       buttonLinkDirectionIndicator +
+      buttonGreyOutExistingLinks +
       buttonPortalList +
       buttonManageOrder +
       buttonDrawTools +
@@ -3863,6 +3977,7 @@ function wrapper(plugin_info) {
       .append(fanfields_buttons);
 
     thisplugin.updateRespectIntelButton();
+    thisplugin.updateGreyOutExistingLinksButton();
 
     //         window.pluginCreateHook('pluginBkmrksEdit');
 

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -2740,17 +2740,22 @@ function wrapper(plugin_info) {
   // and having it in the rotation was mostly confusing. If somehow not already DISTANCE or
   // KEYS (e.g. right after a Task List reset), the next click lands on DISTANCE, the default.
   // Never changes which links exist or which fields form — only how mesh links are oriented.
+  //
+  // Switching mode always starts a clean calculation from the base algorithm, rather than
+  // re-optimizing on top of whatever the previous mode left behind: manualLinkFlips still
+  // holding the old mode's flips would feed straight back into the core algorithm's own build
+  // pass (it consults isLinkFlipped() while constructing the plan, not only afterwards), so a
+  // leftover flip can steer that pass into a different plan than the clean one this mode should
+  // be optimizing from. Dropping the flips, "Less walking" relocations and walk/display order
+  // first guarantees the new mode always computes from the same untouched baseline.
   thisplugin.cycleLinkOrderMode = function () {
     thisplugin.linkOrderMode = (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.DISTANCE)
       ? thisplugin.linkOrderModeENUM.KEYS
       : thisplugin.linkOrderModeENUM.DISTANCE;
 
-    if (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.KEYS) {
-      // KEYS mode never relocates portals — drop any relocation left over from DISTANCE.
-      thisplugin.relocatedForLessWalkingGuids = {};
-      thisplugin.displayOrderGuids = null;
-    }
-    // Re-optimize on top of whatever the plan currently looks like (manual edits included).
+    thisplugin.manualLinkFlips = {};
+    thisplugin.relocatedForLessWalkingGuids = {};
+    thisplugin.displayOrderGuids = null;
     thisplugin._linkOrderRecomputePending = true;
 
     thisplugin.updateLinkOrderModeButton();

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3190,6 +3190,18 @@ function wrapper(plugin_info) {
 
     var flips = thisplugin.flipsFromDirections(current, naturalByKey);
 
+    // Every portal that throws a link AT a given guid, in the final (post-flip) direction —
+    // not just its flipped mesh link: a relocated portal can also receive an ordinary,
+    // never-touched incoming link from some unrelated portal (e.g. two different portals both
+    // happen to link to the same fan point), and whoever throws needs it already captured
+    // either way. computeDistanceOrderReordering uses this as a hard "must come before" bound
+    // — capturing it, and farming enough of its own keys, is only possible once it's actually
+    // been visited, so it can never be walked to AFTER something that throws to it.
+    var incomingSourcesByGuid = {};
+    current.forEach(function (e) {
+      (incomingSourcesByGuid[e.dstGuid] = incomingSourcesByGuid[e.dstGuid] || []).push(e.srcGuid);
+    });
+
     // Relocate each flipped portal to wherever in the walk adds the least extra distance —
     // not necessarily next to its mesh partner, which was picked by the base algorithm for
     // field-geometry reasons and can sit far away geographically. Its anchor link is left
@@ -3197,7 +3209,7 @@ function wrapper(plugin_info) {
     // ever writes to thisplugin.displayOrderGuids (a pure display/walk order), never to
     // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids (the Manage Portal Order
     // feature's own, unrelated, BUILD-order override) — see thisplugin.getDisplayOrder().
-    var reorderResult = thisplugin.computeDistanceOrderReordering(meshFlippedGuids);
+    var reorderResult = thisplugin.computeDistanceOrderReordering(meshFlippedGuids, incomingSourcesByGuid);
     if (reorderResult) {
       thisplugin.displayOrderGuids = reorderResult.order;
       thisplugin.relocatedForLessWalkingGuids = reorderResult.movedGuids;
@@ -3215,14 +3227,19 @@ function wrapper(plugin_info) {
   // that partner was chosen by the base algorithm for field-geometry reasons and can easily
   // sit far away, while the portal itself may in fact be geographically embedded among
   // completely different, unrelated portals — that's exactly where it belongs when walking.
-  // Every gap between two consecutive portals in the walk is a candidate (plus appending after
-  // the last one); the gap whose two endpoints are least stretched by detouring through this
-  // portal wins. Relocated portals are processed one at a time, in thisplugin.sortedFanpoints
-  // order, and each insertion updates the walk before the next portal is placed — so a portal
-  // relocated earlier in this same pass can itself become part of a later portal's cheapest
-  // gap (e.g. two portals that belong together end up next to each other), but the search
-  // itself is otherwise global: nothing pins a portal to its own partner. This is purely a
-  // DISPLAY/WALK reorder: the returned order is only ever meant for
+  // Every gap between two consecutive portals in the walk is a candidate — EXCEPT any gap at
+  // or past the earliest portal in incomingSourcesByGuid[guid] (whoever throws a link at this
+  // one, be it the flipped mesh link or an ordinary link the base algorithm never touched):
+  // that source needs this portal already captured, with enough of its own keys farmed, so it
+  // can never land later in the walk than every one of its sources — it must be visited in
+  // time, not just cheaply. Among the remaining, earlier gaps (plus appending after the last
+  // stop, when nothing constrains it at all), the one whose two endpoints are least stretched
+  // by detouring through this portal wins. Relocated portals are processed one at a time, in
+  // thisplugin.sortedFanpoints order, and each insertion updates the walk before the next
+  // portal is placed — so a portal relocated earlier in this same pass can itself become part
+  // of a later portal's cheapest gap (e.g. two portals that belong together end up next to
+  // each other) and can itself act as a "source" bound for one relocated later. This is purely
+  // a DISPLAY/WALK reorder: the returned order is only ever meant for
   // thisplugin.displayOrderGuids, and must never be applied to thisplugin.sortedFanpoints or
   // thisplugin.manualOrderGuids — the core algorithm only considers, for each portal, the
   // portals preceding it in sortedFanpoints as link partners, so reordering that array (rather
@@ -3230,7 +3247,7 @@ function wrapper(plugin_info) {
   // algorithm produces, not just their direction.
   // Returns null if nothing moved, or { order: <full guid order, anchor first>, movedGuids:
   // <guid -> true, only for portals actually relocated> }.
-  thisplugin.computeDistanceOrderReordering = function (relocateGuids) {
+  thisplugin.computeDistanceOrderReordering = function (relocateGuids, incomingSourcesByGuid) {
     var sorted = thisplugin.sortedFanpoints || [];
     if (!sorted.length) return null;
 
@@ -3252,21 +3269,39 @@ function wrapper(plugin_info) {
     sorted.forEach(function (fp) {
       if (!relocateGuids[fp.guid]) return;
 
-      // Try every gap in the walk so far (between order[i] and order[i+1]), plus appending
-      // after the last stop, and keep whichever adds the least distance.
+      // How far into the walk this portal is allowed to land: strictly before the earliest
+      // of its known sources (skip a source not yet placed — can't bound against a position
+      // that doesn't exist yet). No known source at all means no bound: `limit` stays at
+      // order.length, so appending at the very end is fair game too.
+      var limit = order.length;
+      (incomingSourcesByGuid[fp.guid] || []).forEach(function (srcGuid) {
+        var srcIdx = order.indexOf(srcGuid);
+        if (srcIdx !== -1 && srcIdx < limit) limit = srcIdx;
+      });
+
+      // Try every gap in the walk so far (between order[i] and order[i+1]) that still ends
+      // before `limit`, plus appending after the last stop when nothing bounds it at all —
+      // and keep whichever adds the least distance.
       var bestIdx = -1;
       var bestCost = Infinity;
 
-      for (var i = 0; i < order.length - 1; i++) {
+      var maxGapStart = Math.min(order.length - 2, limit - 2);
+      for (var i = 0; i <= maxGapStart; i++) {
         var a = order[i], b = order[i + 1];
         var cost = dist(a, fp.guid) + dist(fp.guid, b) - dist(a, b);
         if (cost < bestCost) { bestCost = cost; bestIdx = i; }
       }
 
-      var lastCost = dist(order[order.length - 1], fp.guid);
-      if (lastCost < bestCost) { bestCost = lastCost; bestIdx = order.length - 1; }
+      if (limit >= order.length) {
+        var lastCost = dist(order[order.length - 1], fp.guid);
+        if (lastCost < bestCost) { bestCost = lastCost; bestIdx = order.length - 1; }
+      } else if (bestIdx === -1 && limit >= 1) {
+        // No interior gap qualified (the earliest source sits right after the anchor) — the
+        // only spot left that still comes before it is right after the anchor itself.
+        bestIdx = 0;
+      }
 
-      if (bestIdx === -1) return; // empty order (shouldn't normally happen), skip
+      if (bestIdx === -1) return; // no valid spot at all (shouldn't normally happen), skip
 
       order.splice(bestIdx + 1, 0, fp.guid);
       movedGuids[fp.guid] = true;

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -513,14 +513,32 @@ function wrapper(plugin_info) {
   thisplugin.manualOrderGuids = null;
   thisplugin.lastPlanSignature = null;
 
-  // Manual per-link direction overrides (Task List "flip" button, and the "Less walking" /
-  // "Fewer keys" optimizers below).
+  // Manual per-link direction overrides (Task List "flip" button, and the "Fewer keys"
+  // optimizer below).
   // Keyed by undirected link key (getUndirectedLinkKey) -> true.
   // The Task List's own ↔ button only ever touches mesh links between fan points — the
-  // anchor's own fan/star links can't be flipped that way. The "Less walking" optimizer is the
-  // one exception: it can also flip a portal's own anchor link, to turn a 2-link portal into a
-  // full sink (see computeDistanceOrderFlips).
+  // anchor's own fan/star links can't be flipped that way.
   thisplugin.manualLinkFlips = {};
+
+  // "Less walking" (DISTANCE mode): portals it relocated earlier in the walk, right next to
+  // whichever portal already in the walk is closest to them (see computeDistanceOrderFlips).
+  // Keyed by guid -> true. Used only to highlight them in the Task List (green), as a reminder
+  // that this portal must already be captured, with enough of its own keys gathered, by the
+  // time the walk reaches that earlier spot — it's no longer visited in its "natural" position.
+  thisplugin.relocatedForLessWalkingGuids = {};
+
+  // "Less walking" (DISTANCE mode): the walk/display order it relocated portals into (see
+  // computeDistanceOrderReordering). This is a PURE DISPLAY order — never fed back into the
+  // core algorithm, which always builds its links/fields from thisplugin.sortedFanpoints
+  // (and thisplugin.manualOrderGuids, the Manage Portal Order feature's own, unrelated,
+  // BUILD-order override). The core algorithm only considers, for each portal, the portals
+  // that precede it in sortedFanpoints as possible link partners — reordering that array would
+  // silently change which links/fields exist, which is exactly what this feature must never
+  // do. thisplugin.getDisplayOrder() resolves this (or falls back to sortedFanpoints) for
+  // everything that only cares about the walking sequence: the Task List, the on-map position
+  // numbers, the "Path" preview, Google Maps navigation, Portal Route stops, and bookmarks
+  // order. null when no portal is currently relocated.
+  thisplugin.displayOrderGuids = null;
 
   // Link order optimization (menu button "Link order"). This never touches the algorithm
   // itself (which links exist, which fields form) — it only pre-fills / edits
@@ -534,18 +552,52 @@ function wrapper(plugin_info) {
   //           things it would ever need to physically throw — its mesh link flips (mesh
   //           partner -> portal) only if that partner is just as close, or closer, to
   //           whatever comes right after this portal in the walk: i.e. this portal wasn't
-  //           really "on the way". Its anchor link then also flips (subject to SBUL capacity,
-  //           handled by thisplugin.updateLayer() itself), but only when the mesh link just
-  //           flipped too — flipping the anchor link alone, mesh link left throwing outward,
-  //           would save nothing and only cost an anchor outgoing slot for no reason. Other
+  //           really "on the way". Rather than also flipping its anchor link (which would cost
+  //           an anchor outgoing slot for no real benefit), the portal is instead relocated
+  //           earlier in the WALK/DISPLAY order only (thisplugin.displayOrderGuids — see above):
+  //           among every consecutive pair of preceding portals, it's inserted between whichever
+  //           pair minimizes the added detour (cheapest insertion), so it lands genuinely on the
+  //           way between two portals already walked back-to-back. Its anchor link then throws
+  //           normally (portal -> anchor) since that's no longer a costly detour either. Other
   //           portals throwing INTO it later doesn't disqualify it either way — those links
   //           exist regardless and never required it to do anything.
+  // ALGO ("Algorithm", no automatic override) still exists internally as the target of a full
+  // "Reset link orders" (Task List), but the menu button no longer cycles through it — it
+  // toggles only between KEYS and DISTANCE, which default to DISTANCE ("Less walking").
   thisplugin.linkOrderModeENUM = { ALGO: 0, KEYS: 1, DISTANCE: 2 };
-  thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
+  thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.DISTANCE;
   // Set whenever something invalidates the active optimization (anchor/order/geometry change)
   // so the next updateLayer() run recomputes it. Never set for a single manual flip via the
   // Task List ↔ button — that's meant to stick until the user re-optimizes on purpose.
-  thisplugin._linkOrderRecomputePending = false;
+  // Starts true so the default DISTANCE mode computes as soon as the very first plan exists.
+  thisplugin._linkOrderRecomputePending = true;
+
+  // The walk/display order: thisplugin.sortedFanpoints reordered per thisplugin.displayOrderGuids
+  // (the "Less walking" relocation — see above), or thisplugin.sortedFanpoints itself unchanged
+  // if there's no active relocation, or if displayOrderGuids no longer matches the current plan
+  // (stale guid set, wrong length, or a non-anchor first entry). Use this — never
+  // thisplugin.sortedFanpoints directly — for anything that only cares about the sequence a
+  // player actually walks: Task List rows/positions, on-map position numbers, the "Path"
+  // preview, Google Maps navigation, Portal Route stops, bookmark order. The core algorithm
+  // itself, and anything about which links/fields exist, must keep using thisplugin.sortedFanpoints.
+  thisplugin.getDisplayOrder = function () {
+    var sorted = thisplugin.sortedFanpoints || [];
+    var guids = thisplugin.displayOrderGuids;
+    if (!guids || guids.length !== sorted.length) return sorted;
+
+    var byGuid = {};
+    sorted.forEach(function (fp) { byGuid[fp.guid] = fp; });
+
+    var reordered = [];
+    for (var i = 0; i < guids.length; i++) {
+      var fp = byGuid[guids[i]];
+      if (!fp) return sorted; // stale guid set (plan changed since) — ignore it
+      reordered.push(fp);
+    }
+    if (reordered[0].guid !== thisplugin.startingpointGUID) return sorted; // anchor must stay first
+
+    return reordered;
+  };
 
   thisplugin.saveBookmarks = function () {
 
@@ -620,8 +672,8 @@ function wrapper(plugin_info) {
       console.log('Fanfields2: added BOOKMARKS portal ' + bookmark_ID);
     }
 
-    // loop again: ordered(!) to add them as bookmarks
-    thisplugin.sortedFanpoints.forEach(function (point, index) {
+    // loop again: ordered(!) to add them as bookmarks — the walk order, relocations included
+    thisplugin.getDisplayOrder().forEach(function (point, index) {
       if (point.guid) {
         var p = window.portals[point.guid];
         var ll = p.getLatLng();
@@ -640,6 +692,8 @@ function wrapper(plugin_info) {
     // Reset manual order and link flips because the start/anchor changed (ghi#23)
     thisplugin.manualOrderGuids = null;
     thisplugin.manualLinkFlips = {};
+    thisplugin.relocatedForLessWalkingGuids = {};
+    thisplugin.displayOrderGuids = null;
     thisplugin.requestLinkOrderRecompute();
 
     thisplugin.updateLayer();
@@ -705,10 +759,10 @@ function wrapper(plugin_info) {
         'Switch between <i>Clockwise</i> and <i>Counterclockwise</i> order to find an easier route or squeeze out extra fields. ' +
         'For fine control, open <i>Manage Portal Order</i> and drag &amp; drop portals to customise your visit order. ' +
         'Use <i>Path</i> to preview a straight-line route along the current portal sequence. ' +
-        'The <i>Link&nbsp;order</i> button reorients some links (never the algorithm itself, so the plan and visit order stay the same): ' +
-        '<i>Fewer&nbsp;keys</i> tries to lower the highest key count on any single portal, ' +
-        '<i>Less&nbsp;walking</i> flips a 2-link portal\'s links when it isn\'t really on the way to the next stop, so nothing needs to be thrown from it. ' +
-        'Either mode is only a starting point — flip individual links afterwards from the Task List as usual.</p>' +
+        'The <i>Link&nbsp;order</i> button reorients some links (never the algorithm itself — which links exist, which fields form, stays the same): ' +
+        '<i>Fewer&nbsp;keys</i> tries to lower the highest key count on any single portal. ' +
+        '<i>Less&nbsp;walking</i> flips a 2-link portal\'s mesh link when it isn\'t really on the way to the next stop, and relocates that portal earlier in the visit order, right where it best fits between two portals already walked back-to-back — such relocated portals are highlighted green in the Task List as a reminder to capture them (and gather enough of their own keys) early. ' +
+        'Either mode is only a starting point — flip individual links, or reorder portals, afterwards as usual.</p>' +
 
         '<p><b>Freeze recalculation</b><br>' +
         'Use <i>🔒&nbsp;Locked</i> to prevent the script from recalculating while you zoom into details or work with large areas. ' +
@@ -839,7 +893,7 @@ function wrapper(plugin_info) {
   };
 
   thisplugin.getPortalRouteStops = function () {
-    return thisplugin.sortedFanpoints.map(function (portal) {
+    return thisplugin.getDisplayOrder().map(function (portal) {
       var latlng = map.unproject(portal.point, thisplugin.PROJECT_ZOOM);
       var p = portal.portal || window.portals[portal.guid];
       var title = 'unknown title';
@@ -931,7 +985,11 @@ function wrapper(plugin_info) {
 
     var gmnav = 'http://maps.google.com/maps/dir/';
 
-    thisplugin.sortedFanpoints.forEach(function (portal, index) {
+    // The walk order (relocations from "Less walking" included) — never sortedFanpoints
+    // directly, which is the algorithm's own BUILD order and must stay untouched by display.
+    var displayOrder = thisplugin.getDisplayOrder();
+
+    displayOrder.forEach(function (portal, index) {
       var p, lat, lng;
       var latlng = map.unproject(portal.point, thisplugin.PROJECT_ZOOM);
       lat = Math.round(latlng.lat * 10000000) / 10000000
@@ -984,8 +1042,22 @@ function wrapper(plugin_info) {
       } else {
         availableKeysText = '>';
       };
+      // "Less walking" relocated this portal earlier in the walk (see computeDistanceOrderFlips):
+      // flag it so it's captured, with enough of its own keys gathered, ahead of schedule.
+      let isRelocatedForLessWalking = !!(thisplugin.relocatedForLessWalkingGuids && thisplugin.relocatedForLessWalkingGuids[portal.guid]);
+
+      // Both classes can apply at once (a relocated portal whose links are all already
+      // thrown): "relocated" is declared after "done" in the stylesheet, so its green color
+      // wins over "done"'s faded yellow, while "done"'s strikethrough still applies.
+      var portalRowClasses = [];
+      if (allOutgoingLinksDone) portalRowClasses.push('plugin_fanfields2_portal_done');
+      if (isRelocatedForLessWalking) portalRowClasses.push('plugin_fanfields2_portal_relocated');
+      var portalRowClass = portalRowClasses.join(' ');
+
       // Row start
-      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr' + (allOutgoingLinksDone ? ' class="plugin_fanfields2_portal_done"' : '') + '>';
+      text += '<tbody class="plugin_fanfields2_exportText_Portal"><tr' + (portalRowClass ? ' class="' + portalRowClass + '"' : '') +
+        (isRelocatedForLessWalking ? ' title="Relocated here by \'Less walking\': capture this portal and gather enough of its own keys by this point in the walk."' : '') +
+        '>';
       // List Item Index (Pos.)
       text += '<td>' + (index) + '</td>';
 
@@ -1048,12 +1120,12 @@ function wrapper(plugin_info) {
           // Row start
           let linkDetailText = '<tr' + (linkDone ? ' class="plugin_fanfields2_link_done"' : '') + '>';
 
-          // List Item Index (Pos.)
-          linkDetailText += '<td>' + (index) + '.' + thisplugin.sortedFanpoints.indexOf(outPortal) + '</td>';
+          // List Item Index (Pos.) — the target's WALK position, not its build-order index.
+          linkDetailText += '<td>' + (index) + '.' + displayOrder.indexOf(outPortal) + '</td>';
 
           // Action
           linkDetailText += '<td>';
-          linkDetailText += 'Link to ' + thisplugin.sortedFanpoints.indexOf(outPortal);
+          linkDetailText += 'Link to ' + displayOrder.indexOf(outPortal);
           if (meta && meta.invalidUnderField) {
             linkDetailText += ' <span class="plugin_fanfields2_warn" title="Cannot throw from under an existing field (limit ' + thisplugin.maxLinkUnderFieldDistance + 'm).">⚠</span>';
             if (meta.canFlipUnderField) {
@@ -1336,6 +1408,13 @@ function wrapper(plugin_info) {
           tr.plugin_fanfields2_link_done span {
             color: #828284 !important;
             text-decoration: line-through !important;
+          }
+
+          tr.plugin_fanfields2_portal_relocated,
+          tr.plugin_fanfields2_portal_relocated td,
+          tr.plugin_fanfields2_portal_relocated a,
+          tr.plugin_fanfields2_portal_relocated span {
+            color: #2E7D32 !important;
           }
         `;
 
@@ -1832,6 +1911,8 @@ function wrapper(plugin_info) {
     // Reset the order and link flips – new geometry, new base ordering (ghi#23)
     thisplugin.manualOrderGuids = null;
     thisplugin.manualLinkFlips = {};
+    thisplugin.relocatedForLessWalkingGuids = {};
+    thisplugin.displayOrderGuids = null;
     thisplugin.requestLinkOrderRecompute();
 
     $('#plugin_fanfields2_clckwsbtn')
@@ -2116,6 +2197,17 @@ function wrapper(plugin_info) {
       'tr.plugin_fanfields2_portal_done span {\n' +
       '  color: rgba(255, 206, 0, 0.35) !important;\n' +
       '  text-decoration: line-through !important;\n' +
+      '}\n'
+    );
+
+    // Task List: a portal relocated earlier in the walk by "Less walking" is highlighted
+    // green, as a reminder to capture it (and gather enough of its own keys) ahead of schedule.
+    addCSS('\n' +
+      'tr.plugin_fanfields2_portal_relocated,\n' +
+      'tr.plugin_fanfields2_portal_relocated td,\n' +
+      'tr.plugin_fanfields2_portal_relocated a,\n' +
+      'tr.plugin_fanfields2_portal_relocated span {\n' +
+      '  color: #4CAF50 !important;\n' +
       '}\n'
     );
 
@@ -2609,9 +2701,12 @@ function wrapper(plugin_info) {
 
   // Drop all manual link-direction overrides at once (Task List "Reset link orders" button).
   // Also drops back to the plain algorithm mode, since a leftover "Fewer keys"/"Less walking"
-  // label next to zero overrides would be misleading.
+  // label next to zero overrides would be misleading, and reverts any portal relocated by
+  // "Less walking" back to its natural spot in the walk.
   thisplugin.resetLinkFlips = function () {
     thisplugin.manualLinkFlips = {};
+    thisplugin.relocatedForLessWalkingGuids = {};
+    thisplugin.displayOrderGuids = null; // never the user's own Manage Portal Order (manualOrderGuids)
     thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
     thisplugin.updateLinkOrderModeButton();
     thisplugin.updateLayer();
@@ -2644,21 +2739,24 @@ function wrapper(plugin_info) {
       .html('Link&nbsp;order:&nbsp;' + thisplugin.getLinkOrderModeLabel());
   };
 
-  // Cycles the link order optimization mode (menu button). Never changes which links exist or
-  // which fields form — only how mesh links between fan points are oriented.
+  // Cycles the link order optimization mode (menu button) between KEYS ("Fewer keys") and
+  // DISTANCE ("Less walking") — ALGO ("Algorithm", no override) is no longer a cycle stop,
+  // since "Reset link orders" in the Task List already covers "go back to the base algorithm"
+  // and having it in the rotation was mostly confusing. If somehow not already DISTANCE or
+  // KEYS (e.g. right after a Task List reset), the next click lands on DISTANCE, the default.
+  // Never changes which links exist or which fields form — only how mesh links are oriented.
   thisplugin.cycleLinkOrderMode = function () {
-    thisplugin.linkOrderMode++;
-    if (thisplugin.linkOrderMode > thisplugin.linkOrderModeENUM.DISTANCE) {
-      thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
-    }
+    thisplugin.linkOrderMode = (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.DISTANCE)
+      ? thisplugin.linkOrderModeENUM.KEYS
+      : thisplugin.linkOrderModeENUM.DISTANCE;
 
-    if (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.ALGO) {
-      // Back to the plain algorithm: drop every manual override.
-      thisplugin.manualLinkFlips = {};
-    } else {
-      // Re-optimize on top of whatever the plan currently looks like (manual edits included).
-      thisplugin._linkOrderRecomputePending = true;
+    if (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.KEYS) {
+      // KEYS mode never relocates portals — drop any relocation left over from DISTANCE.
+      thisplugin.relocatedForLessWalkingGuids = {};
+      thisplugin.displayOrderGuids = null;
     }
+    // Re-optimize on top of whatever the plan currently looks like (manual edits included).
+    thisplugin._linkOrderRecomputePending = true;
 
     thisplugin.updateLinkOrderModeButton();
     thisplugin.delayedUpdateLayer(0.2);
@@ -2699,7 +2797,9 @@ function wrapper(plugin_info) {
   // Marks impossible links, computes a "valid" triangle list (fields that can actually be created),
   // and provides per-portal counts that ignore invalid links.
   thisplugin.validateUnderFieldLinks = function () {
-    var sorted = thisplugin.sortedFanpoints || [];
+    // Walk order (relocations included) — "under field" validity depends on when a portal is
+    // actually visited, which is the walk/display order, not the algorithm's own build order.
+    var sorted = thisplugin.getDisplayOrder();
     if (sorted.length < 3) {
       thisplugin.invalidUnderFieldLinks = {};
       thisplugin.validTriangles = null;
@@ -3009,13 +3109,19 @@ function wrapper(plugin_info) {
   // from P to the next stop is no farther than the current detour through this portal, so P
   // can throw to it instead and the walk skips the extra stop-and-throw here. If D2 >= D1, the
   // portal genuinely sits on the way to the next stop, so its mesh link is left alone.
-  // The anchor link only ever follows suit: it flips only for a portal whose mesh link just
-  // flipped above, since that's the only way turning it into a full sink (nothing left to throw
-  // from it at all) actually pays off — flipping the anchor link alone, with the mesh link left
-  // throwing outward, would just spend an anchor outgoing slot for no benefit. The anchor flip
-  // only takes effect if the anchor can spare an outgoing slot (SBUL capacity);
-  // simulateDirectedPlan doesn't model that, so thisplugin.updateLayer() itself falls back to
-  // the default direction when there's no room left.
+  // Rather than also flipping the anchor link (which would spend an anchor outgoing slot just
+  // to dodge a walking detour), the portal is instead relocated earlier in the WALK/DISPLAY
+  // order only (thisplugin.displayOrderGuids — see computeDistanceOrderReordering), never in
+  // thisplugin.sortedFanpoints itself: the core algorithm only ever considers, for each
+  // portal, the portals that precede it in sortedFanpoints as link partners, so reordering
+  // that array would silently change which links/fields exist — exactly what this feature must
+  // never do. The relocation only changes where the portal shows up in the Task List, on-map
+  // position numbers, the "Path" preview, navigation, and bookmarks — so it becomes a cheap,
+  // natural detour to WALK there, while every link keeps existing between the exact same two
+  // portals, in whichever direction the flips above settled on. Relocated portals are recorded
+  // in thisplugin.relocatedForLessWalkingGuids purely so the Task List can flag them: since
+  // they're no longer visited in their "natural" position, they must already be captured —
+  // with enough of their own keys gathered — by the time the walk reaches that earlier spot.
   // A portal whose own outgoing count is 1 (just its anchor link) or 3+ is left untouched —
   // the latter is a nested-field hub whose link order the algorithm depends on, where the
   // extra walking is unavoidable.
@@ -3042,10 +3148,8 @@ function wrapper(plugin_info) {
 
     var current = edges.map(function (e) { return $.extend({}, e); });
 
-    // Portals whose mesh link actually flips below. The anchor link flip further down only
-    // ever applies to these — flipping the anchor link on its own, while the mesh link keeps
-    // throwing outward, wouldn't save any walking (the portal would still stand there and
-    // throw its mesh link) and would only cost an anchor outgoing slot for nothing.
+    // Portals whose mesh link actually flips below — these are the ones relocated further
+    // down instead of also having their anchor link flipped.
     var meshFlippedGuids = {};
 
     // Mesh links: only the current thrower can qualify (its own 2 outgoing links are the fan
@@ -3079,17 +3183,97 @@ function wrapper(plugin_info) {
 
     var flips = thisplugin.flipsFromDirections(current, naturalByKey);
 
-    // Anchor links: only for portals whose mesh link just flipped above (see meshFlippedGuids) —
-    // that's the only case where redirecting the anchor link too actually turns the portal into
-    // a full sink and saves anything.
-    sorted.forEach(function (fp) {
-      if (fp.guid === thisplugin.startingpointGUID) return;
-      if (meshFlippedGuids[fp.guid]) {
-        flips[thisplugin.getUndirectedLinkKey(thisplugin.startingpointGUID, fp.guid)] = true;
-      }
-    });
+    // Relocate each portal whose mesh link flipped: right after whichever preceding portal
+    // (by current walk position) is geographically closest to it. Its anchor link is left
+    // alone (natural direction) — it's no longer a costly detour once relocated. This only
+    // ever writes to thisplugin.displayOrderGuids (a pure display/walk order), never to
+    // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids (the Manage Portal Order
+    // feature's own, unrelated, BUILD-order override) — see thisplugin.getDisplayOrder().
+    var reorderResult = thisplugin.computeDistanceOrderReordering(meshFlippedGuids);
+    if (reorderResult) {
+      thisplugin.displayOrderGuids = reorderResult.order;
+      thisplugin.relocatedForLessWalkingGuids = reorderResult.movedGuids;
+    } else {
+      thisplugin.displayOrderGuids = null;
+      thisplugin.relocatedForLessWalkingGuids = {};
+    }
 
     return flips;
+  };
+
+  // For each guid in relocateGuids, finds the cheapest place to insert it among the portals
+  // that precede it in the current walk (thisplugin.sortedFanpoints) — not simply the closest
+  // single predecessor, but the best EDGE to split: among every consecutive pair (A, B) of
+  // preceding, non-relocated portals, the one minimizing dist(A, P) + dist(P, B) - dist(A, B)
+  // (the classic "cheapest insertion" heuristic) — so the portal lands genuinely on the way
+  // between two portals already walked back-to-back, not just near whichever single portal
+  // happens to be nearest (which could be a dead end). Only non-relocated portals are valid
+  // edge endpoints — chaining relocated portals off one another would make the result depend
+  // on processing order. This is purely a DISPLAY/WALK reorder: the returned order is only
+  // ever meant for thisplugin.displayOrderGuids, and must never be applied to
+  // thisplugin.sortedFanpoints or thisplugin.manualOrderGuids — the core algorithm only
+  // considers, for each portal, the portals preceding it in sortedFanpoints as link partners,
+  // so reordering that array (rather than just how it's walked/displayed) would silently
+  // change which links/fields the algorithm produces, not just their direction. Returns null
+  // if nothing moved, or { order: <full guid order, anchor first>, movedGuids: <guid -> true,
+  // only for portals actually relocated> }.
+  thisplugin.computeDistanceOrderReordering = function (relocateGuids) {
+    var sorted = thisplugin.sortedFanpoints || [];
+    if (!sorted.length) return null;
+
+    var indexByGuid = {};
+    var pointByGuid = {};
+    sorted.forEach(function (fp, idx) {
+      indexByGuid[fp.guid] = idx;
+      pointByGuid[fp.guid] = fp.point;
+    });
+
+    function dist(guidA, guidB) {
+      return thisplugin.distanceTo(pointByGuid[guidA], pointByGuid[guidB]);
+    }
+
+    // Everyone NOT being relocated, kept in their original relative order — the stable
+    // backbone the relocated portals get inserted into.
+    var order = sorted
+      .filter(function (fp) { return !relocateGuids[fp.guid]; })
+      .map(function (fp) { return fp.guid; });
+
+    var movedGuids = {};
+
+    sorted.forEach(function (fp) {
+      if (!relocateGuids[fp.guid]) return;
+
+      var idx = indexByGuid[fp.guid];
+
+      // Non-relocated portals that precede fp in the ORIGINAL order, in their relative order —
+      // the only valid edge endpoints ("AVANT son emplacement actuel").
+      var precedingGuids = [];
+      for (var j = 0; j < idx; j++) {
+        if (!relocateGuids[sorted[j].guid]) precedingGuids.push(sorted[j].guid);
+      }
+      if (precedingGuids.length < 2) return; // no edge to split (e.g. right after the anchor)
+
+      var bestA = null;
+      var bestCost = Infinity;
+
+      for (var e = 0; e < precedingGuids.length - 1; e++) {
+        var A = precedingGuids[e];
+        var B = precedingGuids[e + 1];
+        var cost = dist(A, fp.guid) + dist(fp.guid, B) - dist(A, B);
+        if (cost < bestCost) {
+          bestCost = cost;
+          bestA = A;
+        }
+      }
+
+      if (bestA === null) return;
+
+      order.splice(order.indexOf(bestA) + 1, 0, fp.guid);
+      movedGuids[fp.guid] = true;
+    });
+
+    var moved = Object.keys(movedGuids).length > 0;
+    return moved ? { order: order, movedGuids: movedGuids } : null;
   };
 
   // "Fewer keys": greedily re-orients mesh links (any of them, not just 2-link portals) to
@@ -3209,7 +3393,7 @@ function wrapper(plugin_info) {
 
     lg.clearLayers();
 
-    var sorted = that.sortedFanpoints || [];
+    var sorted = that.getDisplayOrder();
     if (sorted.length < 2) return;
 
     // Draw the route as a polyline
@@ -3538,6 +3722,8 @@ function wrapper(plugin_info) {
       thisplugin.lastPlanSignature !== currentSignature) {
 
       thisplugin.manualLinkFlips = {};
+      thisplugin.relocatedForLessWalkingGuids = {};
+      thisplugin.displayOrderGuids = null;
       thisplugin.requestLinkOrderRecompute();
 
       if (thisplugin.showOrderPath) {
@@ -3875,9 +4061,10 @@ function wrapper(plugin_info) {
         bearing = this.getBearing(a, b);
         const distance = thisplugin.distanceTo(a, b);
 
-        // ghi#23 (link flip): manual direction override. Mostly used for mesh links, but the
-        // "Less walking" optimizer can also flip a portal's own anchor link (pb === 0) to make
-        // it a pure sink — handled below via the SBUL capacity check, same as radiating mode.
+        // ghi#23 (link flip): manual direction override. Almost always a mesh link; a portal's
+        // own anchor link (pb === 0) can technically be flipped too, handled below via the same
+        // SBUL capacity check as radiating mode, though no automatic optimizer currently
+        // produces such a flip.
         var flipped = thisplugin.isLinkFlipped(this.sortedFanpoints[pa].guid, this.sortedFanpoints[pb].guid);
 
         if (pb === 0) {
@@ -4050,9 +4237,22 @@ function wrapper(plugin_info) {
     // on top via the Task List ↔ button are left alone otherwise.
     if (thisplugin._linkOrderRecomputePending && thisplugin.linkOrderMode !== thisplugin.linkOrderModeENUM.ALGO) {
       thisplugin._linkOrderRecomputePending = false;
+
+      // The Task List's "Grey out done links" option calls isLinkInGame() per link purely for
+      // display — irrelevant, and needlessly expensive, while the optimizer itself computes.
+      // Suspend it for the duration of the computation and restore it exactly as it was
+      // straight after — never via toggleGreyOutExistingLinks() (redundant here), and before
+      // the updateLayer() call below, so the final render/Task List refresh sees the real
+      // value. _linkOrderRecomputePending is already false, so that call can't loop back here.
+      var greyOutWasOn = thisplugin.greyOutExistingLinks;
+      thisplugin.greyOutExistingLinks = false;
+
       thisplugin.manualLinkFlips = (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.KEYS)
         ? thisplugin.computeKeysOrderFlips()
         : thisplugin.computeDistanceOrderFlips();
+
+      thisplugin.greyOutExistingLinks = greyOutWasOn;
+
       thisplugin.updateLayer();
       return;
     }
@@ -4062,7 +4262,9 @@ function wrapper(plugin_info) {
 
     // and add those we do
     var startLabelDrawn = false;
-    $.each(this.sortedFanpoints, function (idx, fp) {
+    // On-map position numbers follow the walk order (relocations included), matching the
+    // Task List — never the algorithm's own build order.
+    $.each(thisplugin.getDisplayOrder(), function (idx, fp) {
       if (thisplugin.startingpoint !== undefined && fp.point.equals(thisplugin.startingpoint)) {
         drawStartLabel(fp);
         startLabelDrawn = true;
@@ -4294,7 +4496,7 @@ function wrapper(plugin_info) {
     // Link order optimization: leaves the algorithm itself untouched and only reorients mesh
     // links, either for fewer keys on any single portal or for less backtracking while walking.
     var buttonLinkOrder =
-      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_linkorder_btn" onclick="window.plugin.fanfields.cycleLinkOrderMode();" title="Reorient mesh links (not the algorithm itself): fewer keys on any one portal, or less backtracking while walking">Link&nbsp;order:&nbsp;Algorithm</a> ';
+      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_linkorder_btn" onclick="window.plugin.fanfields.cycleLinkOrderMode();" title="Reorient mesh links (not the algorithm itself): fewer keys on any one portal, or less backtracking while walking">Link&nbsp;order:&nbsp;Less&nbsp;walking</a> ';
 
     // Shift anchor
     var buttonShiftAnchor =

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.5.20260912
+// @version         2.8.6.20260912
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-12-190000';
+  plugin_info.dateTimeVersion = '2026-09-12-210000';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.6',
+      changes: [
+        'NEW: "Link order" menu button lets you choose how links are oriented, without changing the fanfield plan itself: keep the algorithm\'s own choice, optimize for fewer keys on any single portal, or optimize for less backtracking while walking the plan.',
+      ],
+    },{
       version: '2.8.5',
       changes: [
         'NEW: Task List strikes through a link line already made in-game for your faction (grey), and once all of a portal\'s links exist, fades and strikes through that whole portal line too (yellow). Toggle via the "Grey out done links" button.',
@@ -508,10 +513,39 @@ function wrapper(plugin_info) {
   thisplugin.manualOrderGuids = null;
   thisplugin.lastPlanSignature = null;
 
-  // Manual per-link direction overrides (Task List "flip" button).
+  // Manual per-link direction overrides (Task List "flip" button, and the "Less walking" /
+  // "Fewer keys" optimizers below).
   // Keyed by undirected link key (getUndirectedLinkKey) -> true.
-  // Only applies to mesh links between fan points; the anchor's fan/star links are never flipped this way.
+  // The Task List's own ↔ button only ever touches mesh links between fan points — the
+  // anchor's own fan/star links can't be flipped that way. The "Less walking" optimizer is the
+  // one exception: it can also flip a portal's own anchor link, to turn a 2-link portal into a
+  // full sink (see computeDistanceOrderFlips).
   thisplugin.manualLinkFlips = {};
+
+  // Link order optimization (menu button "Link order"). This never touches the algorithm
+  // itself (which links exist, which fields form) — it only pre-fills / edits
+  // thisplugin.manualLinkFlips, the very same map the Task List's per-link ↔ button edits by
+  // hand, so the result is always just a starting point the user can keep tweaking manually.
+  // ALGO: pure algorithm, no automatic overrides.
+  // KEYS: greedy rebalancing of mesh link direction to lower the maximum keys needed at any
+  //       single portal.
+  // DISTANCE: when a portal's own OUTGOING count (as the base algorithm computed it — not its
+  //           total degree) is exactly 2 — its anchor link plus one mesh link, the only two
+  //           things it would ever need to physically throw — its mesh link flips (mesh
+  //           partner -> portal) only if that partner is just as close, or closer, to
+  //           whatever comes right after this portal in the walk: i.e. this portal wasn't
+  //           really "on the way". Its anchor link then also flips (subject to SBUL capacity,
+  //           handled by thisplugin.updateLayer() itself), but only when the mesh link just
+  //           flipped too — flipping the anchor link alone, mesh link left throwing outward,
+  //           would save nothing and only cost an anchor outgoing slot for no reason. Other
+  //           portals throwing INTO it later doesn't disqualify it either way — those links
+  //           exist regardless and never required it to do anything.
+  thisplugin.linkOrderModeENUM = { ALGO: 0, KEYS: 1, DISTANCE: 2 };
+  thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
+  // Set whenever something invalidates the active optimization (anchor/order/geometry change)
+  // so the next updateLayer() run recomputes it. Never set for a single manual flip via the
+  // Task List ↔ button — that's meant to stick until the user re-optimizes on purpose.
+  thisplugin._linkOrderRecomputePending = false;
 
   thisplugin.saveBookmarks = function () {
 
@@ -606,6 +640,7 @@ function wrapper(plugin_info) {
     // Reset manual order and link flips because the start/anchor changed (ghi#23)
     thisplugin.manualOrderGuids = null;
     thisplugin.manualLinkFlips = {};
+    thisplugin.requestLinkOrderRecompute();
 
     thisplugin.updateLayer();
   }
@@ -669,7 +704,11 @@ function wrapper(plugin_info) {
         '<p><b>Order & route planning</b><br>' +
         'Switch between <i>Clockwise</i> and <i>Counterclockwise</i> order to find an easier route or squeeze out extra fields. ' +
         'For fine control, open <i>Manage Portal Order</i> and drag &amp; drop portals to customise your visit order. ' +
-        'Use <i>Path</i> to preview a straight-line route along the current portal sequence.</p>' +
+        'Use <i>Path</i> to preview a straight-line route along the current portal sequence. ' +
+        'The <i>Link&nbsp;order</i> button reorients some links (never the algorithm itself, so the plan and visit order stay the same): ' +
+        '<i>Fewer&nbsp;keys</i> tries to lower the highest key count on any single portal, ' +
+        '<i>Less&nbsp;walking</i> flips a 2-link portal\'s links when it isn\'t really on the way to the next stop, so nothing needs to be thrown from it. ' +
+        'Either mode is only a starting point — flip individual links afterwards from the Task List as usual.</p>' +
 
         '<p><b>Freeze recalculation</b><br>' +
         'Use <i>🔒&nbsp;Locked</i> to prevent the script from recalculating while you zoom into details or work with large areas. ' +
@@ -1555,6 +1594,7 @@ function wrapper(plugin_info) {
         .off('click')
         .on('click', function () {
           that.manualOrderGuids = null;
+          that.requestLinkOrderRecompute();
           that.updateLayer();
 
 
@@ -1585,6 +1625,7 @@ function wrapper(plugin_info) {
             that.showUnderFieldWarningOnce = true;
           }
 
+          that.requestLinkOrderRecompute();
           that.delayedUpdateLayer(0.2);
           $('#plugin_fanfields2_order_dialog')
             .dialog('close');
@@ -1791,6 +1832,7 @@ function wrapper(plugin_info) {
     // Reset the order and link flips – new geometry, new base ordering (ghi#23)
     thisplugin.manualOrderGuids = null;
     thisplugin.manualLinkFlips = {};
+    thisplugin.requestLinkOrderRecompute();
 
     $('#plugin_fanfields2_clckwsbtn')
       .html(clockwiseWord + '&nbsp;' + clockwiseSymbol + '');
@@ -2566,9 +2608,60 @@ function wrapper(plugin_info) {
   };
 
   // Drop all manual link-direction overrides at once (Task List "Reset link orders" button).
+  // Also drops back to the plain algorithm mode, since a leftover "Fewer keys"/"Less walking"
+  // label next to zero overrides would be misleading.
   thisplugin.resetLinkFlips = function () {
     thisplugin.manualLinkFlips = {};
+    thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
+    thisplugin.updateLinkOrderModeButton();
     thisplugin.updateLayer();
+  };
+
+  // Marks the active link order optimization (if any) as needing to be recomputed at the next
+  // updateLayer() run. Called wherever the plan's structural basis changes (anchor, visit
+  // order, geometry) — never for a single manual flip via the Task List ↔ button, which is
+  // meant to stick as-is until the user re-optimizes on purpose.
+  thisplugin.requestLinkOrderRecompute = function () {
+    if (thisplugin.linkOrderMode !== thisplugin.linkOrderModeENUM.ALGO) {
+      thisplugin._linkOrderRecomputePending = true;
+    }
+  };
+
+  thisplugin.getLinkOrderModeLabel = function () {
+    switch (thisplugin.linkOrderMode) {
+      case thisplugin.linkOrderModeENUM.KEYS:
+        return 'Fewer keys';
+      case thisplugin.linkOrderModeENUM.DISTANCE:
+        return 'Less walking';
+      case thisplugin.linkOrderModeENUM.ALGO:
+      default:
+        return 'Algorithm';
+    }
+  };
+
+  thisplugin.updateLinkOrderModeButton = function () {
+    $('#plugin_fanfields2_linkorder_btn')
+      .html('Link&nbsp;order:&nbsp;' + thisplugin.getLinkOrderModeLabel());
+  };
+
+  // Cycles the link order optimization mode (menu button). Never changes which links exist or
+  // which fields form — only how mesh links between fan points are oriented.
+  thisplugin.cycleLinkOrderMode = function () {
+    thisplugin.linkOrderMode++;
+    if (thisplugin.linkOrderMode > thisplugin.linkOrderModeENUM.DISTANCE) {
+      thisplugin.linkOrderMode = thisplugin.linkOrderModeENUM.ALGO;
+    }
+
+    if (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.ALGO) {
+      // Back to the plain algorithm: drop every manual override.
+      thisplugin.manualLinkFlips = {};
+    } else {
+      // Re-optimize on top of whatever the plan currently looks like (manual edits included).
+      thisplugin._linkOrderRecomputePending = true;
+    }
+
+    thisplugin.updateLinkOrderModeButton();
+    thisplugin.delayedUpdateLayer(0.2);
   };
 
   // Strict point-in-triangle test in projection space:
@@ -2782,6 +2875,290 @@ function wrapper(plugin_info) {
         });
       }
     }
+  };
+
+  // ---------------------------------------------------------------------
+  // Link order optimization (menu button "Link order: Algorithm / Fewer
+  // keys / Less walking"). This never changes which links exist or which
+  // fields form — thisplugin.updateLayer()'s main algorithm decides that,
+  // exactly as before. It only decides, for mesh links between two fan
+  // points (never the anchor's own fan/star links), which end throws to
+  // the other, by writing into thisplugin.manualLinkFlips — the very same
+  // map the Task List's per-link ↔ button edits by hand.
+  // ---------------------------------------------------------------------
+
+  // Collects the flip-invariant "shape" of the current plan: for every accepted link (fan and
+  // mesh), its two endpoints, distance and field-creation prerequisites, using whatever
+  // direction thisplugin.updateLayer() just settled on for this run (manual flips included).
+  thisplugin.buildLinkOrderEdges = function () {
+    var edges = [];
+    (thisplugin.sortedFanpoints || []).forEach(function (fp) {
+      fp.outgoing.forEach(function (target) {
+        var meta = fp.outgoingMeta ? fp.outgoingMeta[target.guid] : null;
+        edges.push({
+          key: thisplugin.getUndirectedLinkKey(fp.guid, target.guid),
+          isFanLink: (fp.guid === thisplugin.startingpointGUID || target.guid === thisplugin.startingpointGUID),
+          srcGuid: fp.guid,
+          dstGuid: target.guid,
+          distance: thisplugin.distanceTo(fp.point, target.point),
+          creatingFieldsWith: (meta && meta.creatingFieldsWith) ? meta.creatingFieldsWith : []
+        });
+      });
+    });
+    return edges;
+  };
+
+  // For every mesh edge, the direction it would have WITHOUT any manual flip — i.e. reversed
+  // from its current direction if it's currently in manualLinkFlips, unchanged otherwise.
+  thisplugin.getNaturalMeshDirections = function (edges) {
+    var natural = {};
+    edges.forEach(function (e) {
+      if (e.isFanLink) return;
+      natural[e.key] = thisplugin.manualLinkFlips[e.key]
+        ? { srcGuid: e.dstGuid, dstGuid: e.srcGuid }
+        : { srcGuid: e.srcGuid, dstGuid: e.dstGuid };
+    });
+    return natural;
+  };
+
+  // Converts a final set of mesh edge directions back into a manualLinkFlips-shaped map:
+  // flipped (true) wherever the final direction differs from the natural one.
+  thisplugin.flipsFromDirections = function (edges, naturalByKey) {
+    var flips = {};
+    edges.forEach(function (e) {
+      if (e.isFanLink) return;
+      var natural = naturalByKey[e.key];
+      if (natural && e.srcGuid !== natural.srcGuid) flips[e.key] = true;
+    });
+    return flips;
+  };
+
+  // Pure re-simulation of the "under field" walk (mirrors the core logic of
+  // thisplugin.validateUnderFieldLinks, kept separate so exploring flip candidates never
+  // touches the live per-portal state that function maintains). `edges` carry a resolved
+  // direction (srcGuid/dstGuid already reflect the candidate being evaluated). Returns
+  // per-portal incoming ("keys needed") counts and how many links would become impossible
+  // to throw from underneath an existing field.
+  thisplugin.simulateDirectedPlan = function (edges) {
+    var sorted = thisplugin.sortedFanpoints || [];
+    var outgoingByGuid = {};
+    var incomingCount = {};
+    var pointByGuid = {};
+    var pointToGuid = {};
+
+    sorted.forEach(function (fp) {
+      outgoingByGuid[fp.guid] = [];
+      incomingCount[fp.guid] = 0;
+      pointByGuid[fp.guid] = fp.point;
+      pointToGuid[thisplugin.pointKey(fp.point)] = fp.guid;
+    });
+
+    edges.forEach(function (e) {
+      if (outgoingByGuid[e.srcGuid]) outgoingByGuid[e.srcGuid].push(e);
+    });
+
+    var builtLinks = {};
+    (thisplugin.existingIntelPlanLinks || []).forEach(function (link) {
+      if (link.guidA && link.guidB) builtLinks[thisplugin.getUndirectedLinkKey(link.guidA, link.guidB)] = true;
+    });
+
+    var validTriangles = [];
+    var invalidCount = 0;
+
+    for (var vi = 0; vi < sorted.length; vi++) {
+      var srcGuid = sorted[vi].guid;
+      var srcUnder = thisplugin.isPointUnderAnyTriangle(sorted[vi].point, validTriangles);
+
+      var outs = outgoingByGuid[srcGuid] || [];
+      for (var oi = 0; oi < outs.length; oi++) {
+        var e = outs[oi];
+        var dstGuid = e.dstGuid;
+
+        if (srcUnder && e.distance > thisplugin.maxLinkUnderFieldDistance) {
+          invalidCount++;
+          continue;
+        }
+
+        incomingCount[dstGuid] = (incomingCount[dstGuid] || 0) + 1;
+        builtLinks[thisplugin.getUndirectedLinkKey(srcGuid, dstGuid)] = true;
+
+        (e.creatingFieldsWith || []).forEach(function (thirdPoint) {
+          var thirdGuid = pointToGuid[thisplugin.pointKey(thirdPoint)];
+          if (!thirdGuid) return;
+          var e1 = thisplugin.getUndirectedLinkKey(srcGuid, thirdGuid);
+          var e2 = thisplugin.getUndirectedLinkKey(dstGuid, thirdGuid);
+          if (builtLinks[e1] && builtLinks[e2]) {
+            validTriangles.push({ a: thirdPoint, b: pointByGuid[srcGuid], c: pointByGuid[dstGuid] });
+          }
+        });
+      }
+    }
+
+    return { incomingCount: incomingCount, invalidCount: invalidCount };
+  };
+
+  // "Less walking": what matters is a portal's own OUTGOING count as the base algorithm
+  // computed it — not its total degree. A portal that other portals also happen to throw
+  // links AT (later, "from outside") is unaffected by any of this: those incoming links exist
+  // regardless and never require this portal to do anything.
+  //
+  // A portal with exactly 2 outgoing links (its anchor link + one mesh link) is a CANDIDATE,
+  // but its mesh link only actually flips when the portal isn't really "on the way": comparing
+  // its mesh partner P to this portal (D1 = distance(P, portal)) against P to whatever comes
+  // right after this portal in the walk (D2 = distance(P, next)) — if D2 < D1, going straight
+  // from P to the next stop is no farther than the current detour through this portal, so P
+  // can throw to it instead and the walk skips the extra stop-and-throw here. If D2 >= D1, the
+  // portal genuinely sits on the way to the next stop, so its mesh link is left alone.
+  // The anchor link only ever follows suit: it flips only for a portal whose mesh link just
+  // flipped above, since that's the only way turning it into a full sink (nothing left to throw
+  // from it at all) actually pays off — flipping the anchor link alone, with the mesh link left
+  // throwing outward, would just spend an anchor outgoing slot for no benefit. The anchor flip
+  // only takes effect if the anchor can spare an outgoing slot (SBUL capacity);
+  // simulateDirectedPlan doesn't model that, so thisplugin.updateLayer() itself falls back to
+  // the default direction when there's no room left.
+  // A portal whose own outgoing count is 1 (just its anchor link) or 3+ is left untouched —
+  // the latter is a nested-field hub whose link order the algorithm depends on, where the
+  // extra walking is unavoidable.
+  thisplugin.computeDistanceOrderFlips = function () {
+    var edges = thisplugin.buildLinkOrderEdges();
+    var naturalByKey = thisplugin.getNaturalMeshDirections(edges);
+
+    var sorted = thisplugin.sortedFanpoints || [];
+
+    // Each portal's own outgoing count, exactly as the base algorithm computed it for this
+    // run (before this optimizer touches anything), plus its walk position and point.
+    var outgoingCountByGuid = {};
+    var indexByGuid = {};
+    var pointByGuid = {};
+    sorted.forEach(function (fp, idx) {
+      outgoingCountByGuid[fp.guid] = fp.outgoing.length;
+      indexByGuid[fp.guid] = idx;
+      pointByGuid[fp.guid] = fp.point;
+    });
+
+    function dist(guidA, guidB) {
+      return thisplugin.distanceTo(pointByGuid[guidA], pointByGuid[guidB]);
+    }
+
+    var current = edges.map(function (e) { return $.extend({}, e); });
+
+    // Portals whose mesh link actually flips below. The anchor link flip further down only
+    // ever applies to these — flipping the anchor link on its own, while the mesh link keeps
+    // throwing outward, wouldn't save any walking (the portal would still stand there and
+    // throw its mesh link) and would only cost an anchor outgoing slot for nothing.
+    var meshFlippedGuids = {};
+
+    // Mesh links: only the current thrower can qualify (its own 2 outgoing links are the fan
+    // link plus exactly this one mesh link) — flip it to point at the thrower only if the
+    // distance test says it isn't really on the way to the next stop.
+    current.forEach(function (e) {
+      if (e.isFanLink) return;
+      if (outgoingCountByGuid[e.srcGuid] !== 2) return;
+
+      var nextFp = sorted[indexByGuid[e.srcGuid] + 1];
+      if (!nextFp) return; // last portal in the walk, nothing to compare against
+
+      var d1 = dist(e.dstGuid, e.srcGuid);
+      var d2 = dist(e.dstGuid, nextFp.guid);
+      if (!(d2 < d1)) return; // this portal is genuinely on the way, leave it throwing
+
+      var desiredSrc = e.dstGuid;
+      var desiredDst = e.srcGuid;
+
+      var before = thisplugin.simulateDirectedPlan(current);
+      var trial = current.map(function (other) {
+        return (other.key === e.key) ? $.extend({}, other, { srcGuid: desiredSrc, dstGuid: desiredDst }) : other;
+      });
+      var after = thisplugin.simulateDirectedPlan(trial);
+      if (after.invalidCount > before.invalidCount) return; // required for feasibility, keep as-is
+
+      meshFlippedGuids[e.srcGuid] = true;
+      e.srcGuid = desiredSrc;
+      e.dstGuid = desiredDst;
+    });
+
+    var flips = thisplugin.flipsFromDirections(current, naturalByKey);
+
+    // Anchor links: only for portals whose mesh link just flipped above (see meshFlippedGuids) —
+    // that's the only case where redirecting the anchor link too actually turns the portal into
+    // a full sink and saves anything.
+    sorted.forEach(function (fp) {
+      if (fp.guid === thisplugin.startingpointGUID) return;
+      if (meshFlippedGuids[fp.guid]) {
+        flips[thisplugin.getUndirectedLinkKey(thisplugin.startingpointGUID, fp.guid)] = true;
+      }
+    });
+
+    return flips;
+  };
+
+  // "Fewer keys": greedily re-orients mesh links (any of them, not just 2-link portals) to
+  // lower the highest number of keys any single portal needs, never accepting a change that
+  // would make a link impossible to throw from underneath an existing field. This is a
+  // heuristic (repeated local improvement), not a proven-optimal balance.
+  thisplugin.computeKeysOrderFlips = function () {
+    var edges = thisplugin.buildLinkOrderEdges();
+    var naturalByKey = thisplugin.getNaturalMeshDirections(edges);
+
+    var current = edges.map(function (e) { return $.extend({}, e); });
+    var meshEdges = current.filter(function (e) { return !e.isFanLink; });
+
+    var maxIterations = Math.min(500, Math.max(50, meshEdges.length * 10));
+    var stuckGuids = {};
+
+    for (var iter = 0; iter < maxIterations; iter++) {
+      var state = thisplugin.simulateDirectedPlan(current);
+
+      // Pick the not-yet-stuck portal with the highest key count.
+      var targetGuid = null, targetCount = 0;
+      Object.keys(state.incomingCount).forEach(function (guid) {
+        if (stuckGuids[guid]) return;
+        if (state.incomingCount[guid] > targetCount) {
+          targetCount = state.incomingCount[guid];
+          targetGuid = guid;
+        }
+      });
+      if (targetGuid === null) break; // nothing left worth balancing
+
+      // Candidate flips: mesh links currently pointing INTO targetGuid.
+      var candidates = meshEdges.filter(function (e) { return e.dstGuid === targetGuid; });
+      if (candidates.length === 0) {
+        stuckGuids[targetGuid] = true;
+        continue;
+      }
+
+      var bestEdge = null, bestMax = targetCount, bestOtherCount = Infinity;
+      candidates.forEach(function (e) {
+        var trial = current.map(function (other) {
+          return (other.key === e.key) ? $.extend({}, other, { srcGuid: e.dstGuid, dstGuid: e.srcGuid }) : other;
+        });
+        var trialState = thisplugin.simulateDirectedPlan(trial);
+        if (trialState.invalidCount > state.invalidCount) return; // never trade feasibility away
+
+        var trialMax = 0;
+        Object.keys(trialState.incomingCount).forEach(function (guid) {
+          if (trialState.incomingCount[guid] > trialMax) trialMax = trialState.incomingCount[guid];
+        });
+        var otherCount = trialState.incomingCount[e.srcGuid] || 0;
+
+        if (trialMax < bestMax || (trialMax === bestMax && otherCount < bestOtherCount)) {
+          bestMax = trialMax;
+          bestOtherCount = otherCount;
+          bestEdge = e;
+        }
+      });
+
+      if (bestEdge === null) {
+        stuckGuids[targetGuid] = true;
+        continue;
+      }
+
+      var newSrc = bestEdge.dstGuid, newDst = bestEdge.srcGuid;
+      bestEdge.srcGuid = newSrc;
+      bestEdge.dstGuid = newDst;
+    }
+
+    return thisplugin.flipsFromDirections(current, naturalByKey);
   };
 
 
@@ -3161,6 +3538,7 @@ function wrapper(plugin_info) {
       thisplugin.lastPlanSignature !== currentSignature) {
 
       thisplugin.manualLinkFlips = {};
+      thisplugin.requestLinkOrderRecompute();
 
       if (thisplugin.showOrderPath) {
         thisplugin.setOrderPathActive(false);
@@ -3497,12 +3875,15 @@ function wrapper(plugin_info) {
         bearing = this.getBearing(a, b);
         const distance = thisplugin.distanceTo(a, b);
 
-        // ghi#23 (link flip): manual direction override for mesh links (never for the anchor's fan/star links).
-        var flipped = (pb !== 0) && thisplugin.isLinkFlipped(this.sortedFanpoints[pa].guid, this.sortedFanpoints[pb].guid);
+        // ghi#23 (link flip): manual direction override. Mostly used for mesh links, but the
+        // "Less walking" optimizer can also flip a portal's own anchor link (pb === 0) to make
+        // it a pure sink — handled below via the SBUL capacity check, same as radiating mode.
+        var flipped = thisplugin.isLinkFlipped(this.sortedFanpoints[pa].guid, this.sortedFanpoints[pb].guid);
 
         if (pb === 0) {
           var maxLinks = 8 + thisplugin.availableSBUL * 8;
-          if (thisplugin.stardirection === thisplugin.starDirENUM.RADIATING && centerOutgoings < maxLinks) {
+          var wantOutbound = (thisplugin.stardirection === thisplugin.starDirENUM.RADIATING) || flipped;
+          if (wantOutbound && centerOutgoings < maxLinks) {
             outbound = 1;
           } else {
             thisplugin.centerKeys++;
@@ -3519,11 +3900,16 @@ function wrapper(plugin_info) {
           b = paPoint;
         }
 
+        // The actual direction was swapped either by anchor-link capacity (outbound) or by a
+        // mesh-link flip — never by `flipped` alone for pb === 0, since capacity may have
+        // refused the swap above and fallen back to the default direction.
+        var swapped = (pb === 0) ? (outbound === 1) : flipped;
+
         possibleline = {
           a: a,
           b: b,
-          guidA: (outbound === 1 || flipped) ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
-          guidB: (outbound === 1 || flipped) ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
+          guidA: swapped ? this.sortedFanpoints[pb].guid : this.sortedFanpoints[pa].guid,
+          guidB: swapped ? this.sortedFanpoints[pa].guid : this.sortedFanpoints[pb].guid,
           bearing: bearing,
           isJetLink: false,
           isFanLink: (pb === 0),
@@ -3609,21 +3995,13 @@ function wrapper(plugin_info) {
 
           if (possibleline.counts) {
             donelinks.splice(donelinks.length - (this.sortedFanpoints.length - pa), 0, possibleline);
-            if (pb === 0 && thisplugin.stardirection === thisplugin.starDirENUM.RADIATING && outbound === 1) {
+            if (swapped) {
+              // pb is the source (anchor throwing out via capacity/flip, or a flipped mesh link).
               this.sortedFanpoints[pb].outgoing.push(this.sortedFanpoints[pa]);
               this.sortedFanpoints[pa].incoming.push(this.sortedFanpoints[pb]);
 
               // Store per-link metadata (field creation) on the source portal.
               // This avoids recomputing geometry during task list export.
-              this.sortedFanpoints[pb].outgoingMeta[this.sortedFanpoints[pa].guid] = {
-                creatingFieldsWith: possibleline.creatingFieldsWith
-              };
-
-            } else if (flipped) {
-              // ghi#23 (link flip): pb is now the source, pa the destination.
-              this.sortedFanpoints[pb].outgoing.push(this.sortedFanpoints[pa]);
-              this.sortedFanpoints[pa].incoming.push(this.sortedFanpoints[pb]);
-
               this.sortedFanpoints[pb].outgoingMeta[this.sortedFanpoints[pa].guid] = {
                 creatingFieldsWith: possibleline.creatingFieldsWith
               };
@@ -3666,6 +4044,18 @@ function wrapper(plugin_info) {
 
     // Issue #96: validate plan against under-field link distance constraints
     thisplugin.validateUnderFieldLinks();
+
+    // Link order optimization (menu button): recompute once when something invalidated it
+    // (anchor/order/geometry change) — never on every recalculation, so manual tweaks made
+    // on top via the Task List ↔ button are left alone otherwise.
+    if (thisplugin._linkOrderRecomputePending && thisplugin.linkOrderMode !== thisplugin.linkOrderModeENUM.ALGO) {
+      thisplugin._linkOrderRecomputePending = false;
+      thisplugin.manualLinkFlips = (thisplugin.linkOrderMode === thisplugin.linkOrderModeENUM.KEYS)
+        ? thisplugin.computeKeysOrderFlips()
+        : thisplugin.computeDistanceOrderFlips();
+      thisplugin.updateLayer();
+      return;
+    }
 
     // remove any not wanted
     thisplugin.clearAllPortalLabels();
@@ -3901,6 +4291,11 @@ function wrapper(plugin_info) {
     var buttonGreyOutExistingLinks =
       '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_greyout_existing_btn" onclick="window.plugin.fanfields.toggleGreyOutExistingLinks();" title="Grey out and strike through Task List links (and portals) that already exist in-game for your faction">Grey&nbsp;out&nbsp;done&nbsp;links:&nbsp;ON</a> ';
 
+    // Link order optimization: leaves the algorithm itself untouched and only reorients mesh
+    // links, either for fewer keys on any single portal or for less backtracking while walking.
+    var buttonLinkOrder =
+      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_linkorder_btn" onclick="window.plugin.fanfields.cycleLinkOrderMode();" title="Reorient mesh links (not the algorithm itself): fewer keys on any one portal, or less backtracking while walking">Link&nbsp;order:&nbsp;Algorithm</a> ';
+
     // Shift anchor
     var buttonShiftAnchor =
       '<a class="plugin_fanfields2_btn" onclick="window.plugin.fanfields.previousStartingPoint();" title="Less Chaos More Stability">Shift&nbsp;left&nbsp;' +
@@ -3936,6 +4331,7 @@ function wrapper(plugin_info) {
       buttonBookmarksOnly +
       buttonLinkDirectionIndicator +
       buttonGreyOutExistingLinks +
+      buttonLinkOrder +
       buttonPortalList +
       buttonManageOrder +
       buttonDrawTools +
@@ -3978,6 +4374,7 @@ function wrapper(plugin_info) {
 
     thisplugin.updateRespectIntelButton();
     thisplugin.updateGreyOutExistingLinksButton();
+    thisplugin.updateLinkOrderModeButton();
 
     //         window.pluginCreateHook('pluginBkmrksEdit');
 

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -753,11 +753,14 @@ function wrapper(plugin_info) {
         '<p><b>Order & route planning</b><br>' +
         'Switch between <i>Clockwise</i> and <i>Counterclockwise</i> order to find an easier route or squeeze out extra fields. ' +
         'For fine control, open <i>Manage Portal Order</i> and drag &amp; drop portals to customise your visit order. ' +
-        'Use <i>Path</i> to preview a straight-line route along the current portal sequence. ' +
-        'The <i>Link&nbsp;order</i> button reorients some links (never the algorithm itself — which links exist, which fields form, stays the same): ' +
+        'Use <i>Path</i> to preview a straight-line route along the current portal sequence.</p>' +
+
+        '<p><b>Optim (link order)</b><br>' +
+        'The <i>Optim</i> button reorients some links (never the algorithm itself — which links exist, which fields form, stays the same): each click cycles between its two modes, shown in the button label. ' +
         '<i>Fewer&nbsp;keys</i> tries to lower the highest key count on any single portal. ' +
         '<i>Less&nbsp;walking</i> flips a 2-link portal\'s mesh link when it isn\'t really on the way to the next stop, and relocates that portal earlier in the visit order, right where it best fits between two portals already walked back-to-back — such relocated portals are highlighted green in the Task List as a reminder to capture them (and gather enough of their own keys) early. ' +
-        'Either mode is only a starting point — flip individual links, or reorder portals, afterwards as usual.</p>' +
+        'Switching mode always restarts the calculation clean, from the untouched algorithm — either mode is only a starting point, and you can still flip individual links, or reorder portals, afterwards as usual. ' +
+        'To drop every automatic and manual override at once and go back to the plain algorithm, use the Task List\'s <i>Reset&nbsp;link&nbsp;orders</i> button.</p>' +
 
         '<p><b>Freeze recalculation</b><br>' +
         'Use <i>🔒&nbsp;Locked</i> to prevent the script from recalculating while you zoom into details or work with large areas. ' +
@@ -2731,7 +2734,7 @@ function wrapper(plugin_info) {
 
   thisplugin.updateLinkOrderModeButton = function () {
     $('#plugin_fanfields2_linkorder_btn')
-      .html('Link&nbsp;order:&nbsp;' + thisplugin.getLinkOrderModeLabel());
+      .html('Optim:&nbsp;' + thisplugin.getLinkOrderModeLabel());
   };
 
   // Cycles the link order optimization mode (menu button) between KEYS ("Fewer keys") and
@@ -4485,7 +4488,7 @@ function wrapper(plugin_info) {
     // Link order optimization: leaves the algorithm itself untouched and only reorients mesh
     // links, either for fewer keys on any single portal or for less backtracking while walking.
     var buttonLinkOrder =
-      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_linkorder_btn" onclick="window.plugin.fanfields.cycleLinkOrderMode();" title="Reorient mesh links (not the algorithm itself): fewer keys on any one portal, or less backtracking while walking">Link&nbsp;order:&nbsp;Less&nbsp;walking</a> ';
+      '<a class="plugin_fanfields2_btn" id="plugin_fanfields2_linkorder_btn" onclick="window.plugin.fanfields.cycleLinkOrderMode();" title="Reorient mesh links (not the algorithm itself): fewer keys on any one portal, or less backtracking while walking">Optim:&nbsp;Less&nbsp;walking</a> ';
 
     // Shift anchor
     var buttonShiftAnchor =

--- a/iitc_plugin_fanfields2.user.js
+++ b/iitc_plugin_fanfields2.user.js
@@ -3,7 +3,7 @@
 // @id              fanfields@heistergand
 // @name            Fan Fields 2
 // @category        Layer
-// @version         2.8.6.20260912
+// @version         2.8.7.20260913
 // @description     Calculate how to link the portals to create the largest tidy set of nested fields. Enable from the layer chooser.
 // @downloadURL     https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.user.js
 // @updateURL       https://github.com/Heistergand/fanfields2/raw/master/iitc_plugin_fanfields2.meta.js
@@ -25,7 +25,7 @@ function wrapper(plugin_info) {
   // ensure plugin framework is there, even if iitc is not yet loaded
   if (typeof window.plugin !== 'function') window.plugin = function () {};
   plugin_info.buildName = 'main';
-  plugin_info.dateTimeVersion = '2026-09-12-210000';
+  plugin_info.dateTimeVersion = '2026-09-13-120000';
   plugin_info.pluginId = 'fanfields';
 
   /* global L, $, dialog, map, portals, links, plugin  -- eslint*/
@@ -33,6 +33,11 @@ function wrapper(plugin_info) {
 
   var arcname = (window.PLAYER && window.PLAYER.team === 'ENLIGHTENED') ? 'Arc' : '***';
   var changelog = [{
+      version: '2.8.7',
+      changes: [
+        'FIX: Clicking a portal in the Task List threw an error on desktop (window.map.flyTo is not a function).',
+      ],
+    },{
       version: '2.8.6',
       changes: [
         'NEW: "Link order" menu button lets you choose how links are oriented, without changing the fanfield plan itself: keep the algorithm\'s own choice, optimize for fewer keys on any single portal, or optimize for less backtracking while walking the plan.',
@@ -871,7 +876,13 @@ function wrapper(plugin_info) {
 
   thisplugin.flyToPortal = function (latlng, guid) {
 
-    window.map.flyTo(latlng, map.getZoom());
+    // Compat: window.map.flyTo is not available on all IITC builds (desktop). Fall back to
+    // a plain setView, which every build supports.
+    if (typeof window.map.flyTo === 'function') {
+      window.map.flyTo(latlng, map.getZoom());
+    } else {
+      window.map.setView(latlng, map.getZoom());
+    }
     if (window.portals[guid]) window.renderPortalDetails(guid);
     else window.urlPortal = guid;
   }


### PR DESCRIPTION
**Note:** this PR is bigger than the previous ones, but it genuinely optimizes how much walking a fanfield plan takes to execute.

## What's new

- New **Optim** menu button that reorients some mesh links without changing the fanfield plan itself (which links exist, which fields form, stays exactly the same):
  - **Fewer keys** balances the number of keys needed at any single portal.
  - **Less walking** cuts backtracking during the walk: it flips links that aren't really "on the way" and relocates those portals to wherever they best fit in the visit order.
- Portals relocated by "Less walking" are highlighted in green in the Task List, as a reminder to capture them (and gather enough of their own keys) ahead of schedule.
- Switching between Optim modes always restarts from a clean calculation, so results stay predictable.
- The Help dialog now documents the Optim button in its own dedicated section.
